### PR TITLE
MAKE-927: remove work units from pool implementations

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -13,11 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type workUnit struct {
-	job    amboy.Job
-	cancel context.CancelFunc
-}
-
 func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
 	didRun := runJob(ctx, job, q, time.Now())
 
@@ -108,11 +103,12 @@ func runJob(ctx context.Context, job amboy.Job, q amboy.Queue, startAt time.Time
 	return true
 }
 
-func worker(ctx context.Context, id string, jobs <-chan workUnit, q amboy.Queue, wg *sync.WaitGroup) {
+func worker(bctx context.Context, id string, jobs <-chan amboy.Job, q amboy.Queue, wg *sync.WaitGroup) {
 	var (
 		err    error
 		job    amboy.Job
 		cancel context.CancelFunc
+		ctx    context.Context
 	)
 
 	wg.Add(1)
@@ -123,10 +119,10 @@ func worker(ctx context.Context, id string, jobs <-chan workUnit, q amboy.Queue,
 		if err != nil {
 			if job != nil {
 				job.AddError(err)
-				q.Complete(ctx, job)
+				q.Complete(bctx, job)
 			}
 			// start a replacement worker.
-			go worker(ctx, id, jobs, q, wg)
+			go worker(bctx, id, jobs, q, wg)
 		}
 
 		if cancel != nil {
@@ -136,25 +132,22 @@ func worker(ctx context.Context, id string, jobs <-chan workUnit, q amboy.Queue,
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-bctx.Done():
 			return
-		case wu := <-jobs:
-			if wu.job == nil {
+		case job = <-jobs:
+			if job == nil {
 				continue
 			}
 
-			job = wu.job
-			cancel = wu.cancel
+			ctx, cancel = context.WithCancel(bctx)
 			executeJob(ctx, id, job, q)
 			cancel()
 		}
 	}
 }
 
-func startWorkerServer(ctx context.Context, q amboy.Queue, wg *sync.WaitGroup) <-chan workUnit {
-	var nctx context.Context
-
-	output := make(chan workUnit)
+func startWorkerServer(ctx context.Context, q amboy.Queue, wg *sync.WaitGroup) <-chan amboy.Job {
+	output := make(chan amboy.Job)
 
 	wg.Add(1)
 	go func() {
@@ -164,21 +157,21 @@ func startWorkerServer(ctx context.Context, q amboy.Queue, wg *sync.WaitGroup) <
 			case <-ctx.Done():
 				return
 			default:
-				wu := workUnit{}
-				nctx, wu.cancel = context.WithCancel(ctx)
-
-				job := q.Next(nctx)
+				job := q.Next(ctx)
 				if job == nil {
 					continue
 				}
 
 				if job.Status().Completed {
-					grip.Debugf("job '%s' was dispatched from the queue but was completed",
-						job.ID())
+					grip.Debug(message.Fields{
+						"message":    "completed job dispatched from the queue",
+						"job":        job.ID(),
+						"queue_type": fmt.Sprintf("%T", q),
+						"stat":       job.Status(),
+					})
 					continue
 				}
-				wu.job = job
-				output <- wu
+				output <- job
 			}
 		}
 	}()

--- a/pool/local_test.go
+++ b/pool/local_test.go
@@ -159,8 +159,8 @@ func TestPanicJobPanics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	for wu := range jobsChanWithPanicingJobs(ctx, 8) {
-		assert.Panics(func() { wu.job.Run(ctx) })
+	for job := range jobsChanWithPanicingJobs(ctx, 8) {
+		assert.Panics(func() { job.Run(ctx) })
 	}
 
 }

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -187,8 +187,8 @@ func (j *jobThatPanics) Run(_ context.Context) {
 	panic("panic err")
 }
 
-func jobsChanWithPanicingJobs(ctx context.Context, num int) <-chan workUnit {
-	out := make(chan workUnit)
+func jobsChanWithPanicingJobs(ctx context.Context, num int) <-chan amboy.Job {
+	out := make(chan amboy.Job)
 
 	go func() {
 		defer close(out) // nolint
@@ -201,7 +201,7 @@ func jobsChanWithPanicingJobs(ctx context.Context, num int) <-chan workUnit {
 			select {
 			case <-ctx.Done():
 				return
-			case out <- workUnit{job: &jobThatPanics{}, cancel: func() {}}:
+			case out <- &jobThatPanics{}:
 				count++
 			}
 		}

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -392,12 +392,6 @@ func (q *shuffledLocal) Complete(ctx context.Context, j amboy.Job) {
 
 		id := j.ID()
 
-		if ctx.Err() != nil {
-			grip.Noticef("did not complete %s job, because operation "+
-				"was canceled.", id)
-			return
-		}
-
 		completed[id] = j
 		delete(dispatched, id)
 		toDelete.Push(id)


### PR DESCRIPTION
discovered this when trying to change the contexts. when queues were
responsible for locking, the context that you passed to queue.Next()
was used to cancel the lock pingging, but now, there's no need for
that, and we can just return to a channel of jobs in the pool
implementation.