### PR TITLE
MAKE-902: make LockTimeout configurable

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -77,8 +77,8 @@ type Job interface {
 	// not-in-progress, and should be a no-op if the job does not
 	// belong to the owner. In general the owner should be the value
 	// of queue.ID()
-	Lock(string) error
-	Unlock(string)
+	Lock(owner string, lockTimeout time.Duration) error
+	Unlock(owner string, lockTimeout time.Duration)
 
 	// Scope provides the ability to provide more configurable
 	// exclusion a job can provide.
@@ -185,7 +185,11 @@ type Queue interface {
 
 	// Makes it possible to detect if a Queue has started
 	// dispatching jobs to runners.
+	// kim: TODO: remove and replace with Info()
 	Started() bool
+
+	// Info returns information related to management of the Queue.
+	Info() QueueInfo
 
 	// Used to mark a Job complete and remove it from the pending
 	// work of the queue.
@@ -221,6 +225,11 @@ type Queue interface {
 	// Begins the execution of the job Queue, using the embedded
 	// Runner.
 	Start(context.Context) error
+}
+
+type QueueInfo struct {
+	Started     bool
+	LockTimeout time.Duration
 }
 
 // QueueGroup describes a group of queues. Each queue is indexed by a

--- a/interface.go
+++ b/interface.go
@@ -183,11 +183,6 @@ type Queue interface {
 	// blocking, but may be interrupted with a canceled context.
 	Next(context.Context) Job
 
-	// Makes it possible to detect if a Queue has started
-	// dispatching jobs to runners.
-	// kim: TODO: remove and replace with Info()
-	Started() bool
-
 	// Info returns information related to management of the Queue.
 	Info() QueueInfo
 

--- a/interface.go
+++ b/interface.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mongodb/grip"
 )
 
-// LockTimeout describes the period of time that a queue will respect
+// LockTimeout describes the default period of time that a queue will respect
 // a stale lock from another queue before beginning work on a job.
 const LockTimeout = 10 * time.Minute
 
@@ -222,6 +222,7 @@ type Queue interface {
 	Start(context.Context) error
 }
 
+// QueueInfo describes runtime information associated with a Queue.
 type QueueInfo struct {
 	Started     bool
 	LockTimeout time.Duration

--- a/job/base.go
+++ b/job/base.go
@@ -111,11 +111,11 @@ func (b *Base) ID() string {
 // uniquely identify the runtime instance of the queue that holds the
 // lock, and the method returns an error if the lock cannot be
 // acquired.
-func (b *Base) Lock(id string) error {
+func (b *Base) Lock(id string, lockTimeout time.Duration) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	if b.status.InProgress && time.Since(b.status.ModificationTime) < amboy.LockTimeout && b.status.Owner != id {
+	if b.status.InProgress && time.Since(b.status.ModificationTime) < lockTimeout && b.status.Owner != id {
 		return errors.Errorf("cannot take lock for '%s' because lock has been held for %s by %s",
 			id, time.Since(b.status.ModificationTime), b.status.Owner)
 	}
@@ -128,11 +128,11 @@ func (b *Base) Lock(id string) error {
 
 // Unlock attempts to remove the current lock state in the job, if
 // possible.
-func (b *Base) Unlock(id string) {
+func (b *Base) Unlock(id string, lockTimeout time.Duration) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	if b.status.InProgress && time.Since(b.status.ModificationTime) < amboy.LockTimeout && b.status.Owner != id {
+	if b.status.InProgress && time.Since(b.status.ModificationTime) < lockTimeout && b.status.Owner != id {
 		return
 	}
 

--- a/logger/sender_test.go
+++ b/logger/sender_test.go
@@ -59,7 +59,7 @@ func (s *SenderSuite) SetupTest() {
 
 	s.queue = queue.NewLocalLimitedSize(4, 128)
 	s.NoError(s.queue.Start(ctx))
-	s.Require().True(s.queue.Started())
+	s.Require().True(s.queue.Info().Started)
 
 	s.senders["single-shared"] = MakeQueueSender(ctx, s.queue, s.mock)
 	s.senders["multi-shared"] = MakeQueueMultiSender(ctx, s.queue, s.mock)

--- a/makefile
+++ b/makefile
@@ -121,7 +121,7 @@ $(buildDir)/output.%.race:$(buildDir)/ .FORCE
 	$(goEnv) $(gobin) test $(testArgs) -race ./$(subst -,/,$*) | tee  $@
 #  targets to run any tests in the top-level package
 $(buildDir)/output.$(name).test:$(buildDir)/
-	$(goEnv) $(gobin) test $(testArgs) $@ ./ | tee $@
+	$(goEnv) $(gobin) test $(testArgs) ./ | tee $@
 $(buildDir)/output.$(name).race:$(buildDir)/
 	$(goEnv) $(gobin) test $(testArgs) -race ./ | tee $@
 #  targets to generate gotest output from the linter.

--- a/management/mongodb.go
+++ b/management/mongodb.go
@@ -47,6 +47,7 @@ func (o *DBQueueManagerOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(o.SingleGroup && o.ByGroups, "cannot specify conflicting group options")
 	catcher.NewWhen(o.Name == "", "must specify queue name")
+	catcher.Wrap(o.Options.Validate(), "invalid mongo options")
 	return catcher.Resolve()
 }
 

--- a/management/mongodb.go
+++ b/management/mongodb.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/queue"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -243,7 +242,8 @@ func (db *dbQueueManager) JobStatus(ctx context.Context, f StatusFilter) (*JobSt
 		match["status.completed"] = false
 	case Stale:
 		match["status.in_prog"] = true
-		match["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-amboy.LockTimeout)}
+		// kim: TODO: pass in lock timeout
+		match["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
 		match["status.completed"] = false
 	case Completed:
 		match["status.in_prog"] = false
@@ -384,7 +384,8 @@ func (db *dbQueueManager) JobIDsByState(ctx context.Context, jobType string, f S
 		query["status.in_prog"] = false
 	case Stale:
 		query["status.in_prog"] = true
-		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-amboy.LockTimeout)}
+		// kim: TODO: pass in lock timeout
+		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
 	case Completed:
 		query["status.in_prog"] = false
 		query["status.completed"] = true
@@ -602,7 +603,8 @@ func (db *dbQueueManager) completeJobs(ctx context.Context, query bson.M, f Stat
 		query["status.in_prog"] = true
 	case Stale:
 		query["status.in_prog"] = true
-		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-amboy.LockTimeout)}
+		// kim: TODO: pass in lock timeout
+		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
 	case Pending:
 		query["status.completed"] = false
 		query["status.in_prog"] = false

--- a/management/mongodb.go
+++ b/management/mongodb.go
@@ -242,8 +242,7 @@ func (db *dbQueueManager) JobStatus(ctx context.Context, f StatusFilter) (*JobSt
 		match["status.completed"] = false
 	case Stale:
 		match["status.in_prog"] = true
-		// kim: TODO: pass in lock timeout
-		match["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
+		match["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.LockTimeout)}
 		match["status.completed"] = false
 	case Completed:
 		match["status.in_prog"] = false
@@ -384,8 +383,7 @@ func (db *dbQueueManager) JobIDsByState(ctx context.Context, jobType string, f S
 		query["status.in_prog"] = false
 	case Stale:
 		query["status.in_prog"] = true
-		// kim: TODO: pass in lock timeout
-		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
+		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.LockTimeout)}
 	case Completed:
 		query["status.in_prog"] = false
 		query["status.completed"] = true
@@ -603,8 +601,7 @@ func (db *dbQueueManager) completeJobs(ctx context.Context, query bson.M, f Stat
 		query["status.in_prog"] = true
 	case Stale:
 		query["status.in_prog"] = true
-		// kim: TODO: pass in lock timeout
-		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.GetLockTimeout())}
+		query["status.mod_ts"] = bson.M{"$gt": time.Now().Add(-db.opts.Options.LockTimeout)}
 	case Pending:
 		query["status.completed"] = false
 		query["status.in_prog"] = false

--- a/management/queue.go
+++ b/management/queue.go
@@ -58,7 +58,7 @@ func (m *queueManager) JobStatus(ctx context.Context, f StatusFilter) (*JobStatu
 		}
 	case Stale:
 		for stat := range m.queue.JobStats(ctx) {
-			if !stat.Completed && stat.InProgress && time.Since(stat.ModificationTime) > amboy.LockTimeout {
+			if !stat.Completed && stat.InProgress && time.Since(stat.ModificationTime) > m.queue.Info().LockTimeout {
 				job, ok := m.queue.Get(ctx, stat.ID)
 				if ok {
 					counters[job.Type().Name]++
@@ -221,7 +221,7 @@ func (m *queueManager) JobIDsByState(ctx context.Context, jobType string, f Stat
 					continue
 				}
 			}
-			if !stat.Completed && stat.InProgress && time.Since(stat.ModificationTime) > amboy.LockTimeout {
+			if !stat.Completed && stat.InProgress && time.Since(stat.ModificationTime) > m.queue.Info().LockTimeout {
 				ids = append(ids, stat.ID)
 			}
 		}
@@ -514,7 +514,7 @@ func (m *queueManager) CompleteJobsByType(ctx context.Context, f StatusFilter, j
 
 		switch f {
 		case Stale:
-			if !stat.InProgress || time.Since(stat.ModificationTime) < amboy.LockTimeout {
+			if !stat.InProgress || time.Since(stat.ModificationTime) < m.queue.Info().LockTimeout {
 				continue
 			}
 		case InProgress:
@@ -553,7 +553,7 @@ func (m *queueManager) CompleteJobs(ctx context.Context, f StatusFilter) error {
 
 		switch f {
 		case Stale:
-			if stat.InProgress && time.Since(stat.ModificationTime) > amboy.LockTimeout {
+			if stat.InProgress && time.Since(stat.ModificationTime) > m.queue.Info().LockTimeout {
 				continue
 			}
 		case InProgress:

--- a/pool/local_test.go
+++ b/pool/local_test.go
@@ -84,7 +84,7 @@ func (s *LocalWorkersSuite) TestPoolStartsAndProcessesJobs() {
 	}
 
 	s.False(s.pool.Started())
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -96,7 +96,7 @@ func (s *LocalWorkersSuite) TestPoolStartsAndProcessesJobs() {
 	}
 
 	s.True(s.pool.Started())
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	amboy.WaitInterval(ctx, s.queue, 100*time.Millisecond)
 

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -76,11 +76,14 @@ func (q *QueueTester) Get(ctx context.Context, name string) (amboy.Job, bool) {
 	return job, ok
 }
 
-func (q *QueueTester) Started() bool {
+func (q *QueueTester) Info() amboy.QueueInfo {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	return q.started
+	return amboy.QueueInfo{
+		Started:     q.started,
+		LockTimeout: amboy.LockTimeout,
+	}
 }
 
 func (q *QueueTester) Complete(ctx context.Context, j amboy.Job) {
@@ -107,7 +110,7 @@ func (q *QueueTester) Runner() amboy.Runner {
 }
 
 func (q *QueueTester) SetRunner(r amboy.Runner) error {
-	if q.Started() {
+	if q.Info().Started {
 		return errors.New("cannot set runner in a started pool")
 	}
 	q.pool = r
@@ -124,7 +127,7 @@ func (q *QueueTester) Next(ctx context.Context) amboy.Job {
 }
 
 func (q *QueueTester) Start(ctx context.Context) error {
-	if q.Started() {
+	if q.Info().Started {
 		return nil
 	}
 

--- a/pool/rate_limiting.go
+++ b/pool/rate_limiting.go
@@ -62,12 +62,12 @@ type simpleRateLimited struct {
 	queue    amboy.Queue
 	canceler context.CancelFunc
 	wg       sync.WaitGroup
-	mu       sync.Mutex
+	mu       sync.RWMutex
 }
 
 func (p *simpleRateLimited) Started() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 
 	return p.canceler != nil
 }

--- a/pool/rate_limiting_average.go
+++ b/pool/rate_limiting_average.go
@@ -114,8 +114,17 @@ func (p *ewmaRateLimiting) getNextTime(dur time.Duration) time.Duration {
 	return (excessTime / time.Duration(p.target))
 }
 
-func (p *ewmaRateLimiting) Started() bool { return p.canceler != nil }
+func (p *ewmaRateLimiting) Started() bool {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return p.canceler != nil
+}
+
 func (p *ewmaRateLimiting) Start(ctx context.Context) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	if p.canceler != nil {
 		return nil
 	}

--- a/pool/single_test.go
+++ b/pool/single_test.go
@@ -55,7 +55,7 @@ func (s *SingleRunnerSuite) TestPoolStartsAndProcessesJobs() {
 	}
 
 	s.False(s.pool.Started())
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -66,7 +66,7 @@ func (s *SingleRunnerSuite) TestPoolStartsAndProcessesJobs() {
 	}
 
 	s.True(s.pool.Started())
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	amboy.WaitInterval(ctx, s.queue, 100*time.Millisecond)
 

--- a/queue/adaptive_order.go
+++ b/queue/adaptive_order.go
@@ -87,7 +87,7 @@ func (q *adaptiveLocalOrdering) reactor(ctx context.Context) {
 }
 
 func (q *adaptiveLocalOrdering) Put(ctx context.Context, j amboy.Job) error {
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.New("cannot add job to unopened queue")
 	}
 
@@ -115,7 +115,7 @@ func (q *adaptiveLocalOrdering) Put(ctx context.Context, j amboy.Job) error {
 }
 
 func (q *adaptiveLocalOrdering) Save(ctx context.Context, j amboy.Job) error {
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.New("cannot add job to unopened queue")
 	}
 
@@ -140,7 +140,7 @@ func (q *adaptiveLocalOrdering) Save(ctx context.Context, j amboy.Job) error {
 }
 
 func (q *adaptiveLocalOrdering) Get(ctx context.Context, name string) (amboy.Job, bool) {
-	if !q.Started() {
+	if !q.Info().Started {
 		return nil, false
 	}
 
@@ -219,7 +219,7 @@ func (q *adaptiveLocalOrdering) JobStats(ctx context.Context) <-chan amboy.JobSt
 }
 
 func (q *adaptiveLocalOrdering) Stats(ctx context.Context) amboy.QueueStats {
-	if !q.Started() {
+	if !q.Info().Started {
 		return amboy.QueueStats{}
 	}
 
@@ -243,8 +243,6 @@ func (q *adaptiveLocalOrdering) Stats(ctx context.Context) amboy.QueueStats {
 		return <-ret
 	}
 }
-
-func (q *adaptiveLocalOrdering) Started() bool { return q.operations != nil }
 
 func (q *adaptiveLocalOrdering) Info() amboy.QueueInfo {
 	return amboy.QueueInfo{

--- a/queue/adaptive_order.go
+++ b/queue/adaptive_order.go
@@ -245,6 +245,14 @@ func (q *adaptiveLocalOrdering) Stats(ctx context.Context) amboy.QueueStats {
 }
 
 func (q *adaptiveLocalOrdering) Started() bool { return q.operations != nil }
+
+func (q *adaptiveLocalOrdering) Info() amboy.QueueInfo {
+	return amboy.QueueInfo{
+		Started:     q.operations != nil,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 func (q *adaptiveLocalOrdering) Next(ctx context.Context) amboy.Job {
 	ret := make(chan amboy.Job)
 	op := func(ctx context.Context, items *adaptiveOrderItems, fixed *fixedStorage) {

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -25,6 +25,9 @@ type remoteQueueDriver interface {
 	JobStats(context.Context) <-chan amboy.JobStatusInfo
 	Complete(context.Context, amboy.Job) error
 
+	// kim: TODO: maybe remove
+	LockTimeout() time.Duration
+
 	SetDispatcher(Dispatcher)
 	Dispatcher() Dispatcher
 }
@@ -48,6 +51,17 @@ type MongoDBOptions struct {
 	// field. If set to zero, the TTL index will not be created and
 	// and documents may live forever in the database.
 	TTL time.Duration
+	// LockTimeout overrides the default job lock timeout if set.
+	LockTimeout time.Duration
+}
+
+// GetLockTimeout returns the lock timeout specified by the options, or
+// amboy.LockTimeout as the default.
+func (opts *MongoDBOptions) GetLockTimeout() time.Duration {
+	if opts.LockTimeout <= time.Duration(0) {
+		return amboy.LockTimeout
+	}
+	return opts.LockTimeout
 }
 
 // DefaultMongoDBOptions constructs a new options object with default

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -73,9 +73,9 @@ func DefaultMongoDBOptions() MongoDBOptions {
 	}
 }
 
-// ValidateAndDefault validates that the required options are given and sets
-// fields that are unspecified and have a default value.
-func (opts *MongoDBOptions) ValidateAndDefault() error {
+// Validate validates that the required options are given and sets fields that
+// are unspecified and have a default value.
+func (opts *MongoDBOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(opts.URI == "", "must specify connection URI")
 	catcher.NewWhen(opts.DB == "", "must specify database")

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -34,27 +34,34 @@ type mongoDriver struct {
 // NewMongoDriver constructs a MongoDB backed queue driver
 // implementation using the go.mongodb.org/mongo-driver as the
 // database interface.
-func newMongoDriver(name string, opts MongoDBOptions) remoteQueueDriver {
+func newMongoDriver(name string, opts MongoDBOptions) (remoteQueueDriver, error) {
 	host, _ := os.Hostname() // nolint
 
-	if !opts.Format.IsValid() {
-		opts.Format = amboy.BSON
+	if err := opts.ValidateAndDefault(); err != nil {
+		return nil, errors.Wrap(err, "invalid mongo driver options")
 	}
 
 	return &mongoDriver{
 		name:       name,
 		opts:       opts,
 		instanceID: fmt.Sprintf("%s.%s.%s", name, host, uuid.New()),
-	}
+	}, nil
 }
 
 // openNewMongoDriver constructs and opens a new MongoDB driver instance
 // using the specified session. It is equivalent to calling
 // NewMongoDriver() and calling driver.Open().
 func openNewMongoDriver(ctx context.Context, name string, opts MongoDBOptions, client *mongo.Client) (remoteQueueDriver, error) {
-	d := newMongoDriver(name, opts).(*mongoDriver)
+	d, err := newMongoDriver(name, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create driver")
+	}
+	md, ok := d.(*mongoDriver)
+	if !ok {
+		return nil, errors.New("amboy programmer error: incorrect constructor")
+	}
 
-	if err := d.start(ctx, client); err != nil {
+	if err := md.start(ctx, client); err != nil {
 		return nil, errors.Wrap(err, "problem starting driver")
 	}
 
@@ -65,11 +72,11 @@ func openNewMongoDriver(ctx context.Context, name string, opts MongoDBOptions, c
 // prefixes job ids with a prefix and adds the group field to the
 // documents in the database which makes it possible to manage
 // distinct queues with a single MongoDB collection.
-func newMongoGroupDriver(name string, opts MongoDBOptions, group string) remoteQueueDriver {
+func newMongoGroupDriver(name string, opts MongoDBOptions, group string) (remoteQueueDriver, error) {
 	host, _ := os.Hostname() // nolint
 
-	if !opts.Format.IsValid() {
-		opts.Format = amboy.BSON
+	if err := opts.ValidateAndDefault(); err != nil {
+		return nil, errors.Wrap(err, "invalid mongo driver options")
 	}
 	opts.UseGroups = true
 	opts.GroupName = group
@@ -78,14 +85,18 @@ func newMongoGroupDriver(name string, opts MongoDBOptions, group string) remoteQ
 		name:       name,
 		opts:       opts,
 		instanceID: fmt.Sprintf("%s.%s.%s.%s", name, group, host, uuid.New()),
-	}
+	}, nil
 }
 
 // OpenNewMongoGroupDriver constructs and opens a new MongoDB driver instance
 // using the specified session. It is equivalent to calling
 // NewMongoGroupDriver() and calling driver.Open().
 func openNewMongoGroupDriver(ctx context.Context, name string, opts MongoDBOptions, group string, client *mongo.Client) (remoteQueueDriver, error) {
-	d, ok := newMongoGroupDriver(name, opts, group).(*mongoDriver)
+	d, err := newMongoGroupDriver(name, opts, group)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create driver")
+	}
+	md, ok := d.(*mongoDriver)
 	if !ok {
 		return nil, errors.New("amboy programmer error: incorrect constructor")
 	}
@@ -93,7 +104,7 @@ func openNewMongoGroupDriver(ctx context.Context, name string, opts MongoDBOptio
 	opts.UseGroups = true
 	opts.GroupName = group
 
-	if err := d.start(ctx, client); err != nil {
+	if err := md.start(ctx, client); err != nil {
 		return nil, errors.Wrap(err, "problem starting driver")
 	}
 
@@ -890,12 +901,11 @@ func (d *mongoDriver) Stats(ctx context.Context) amboy.QueueStats {
 	}
 }
 
-// kim: TODO: maybe remove
 func (d *mongoDriver) LockTimeout() time.Duration {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.opts.GetLockTimeout()
+	return d.opts.LockTimeout
 }
 
 func (d *mongoDriver) Dispatcher() Dispatcher {

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -37,7 +37,7 @@ type mongoDriver struct {
 func newMongoDriver(name string, opts MongoDBOptions) (remoteQueueDriver, error) {
 	host, _ := os.Hostname() // nolint
 
-	if err := opts.ValidateAndDefault(); err != nil {
+	if err := opts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid mongo driver options")
 	}
 
@@ -75,7 +75,7 @@ func openNewMongoDriver(ctx context.Context, name string, opts MongoDBOptions, c
 func newMongoGroupDriver(name string, opts MongoDBOptions, group string) (remoteQueueDriver, error) {
 	host, _ := os.Hostname() // nolint
 
-	if err := opts.ValidateAndDefault(); err != nil {
+	if err := opts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid mongo driver options")
 	}
 	opts.UseGroups = true

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -268,3 +268,8 @@ func (s *DriverSuite) TestStatsMethodReturnsAllJobs() {
 	s.Equal(len(names), counter)
 	s.Equal(counter, 30)
 }
+
+// kim: TODO: write test
+// func (s *DriverSuite) TestInfoReturnsConfigurableLockTimeout() {
+//     s.driver.LockTimeout()
+// }

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -211,7 +211,7 @@ func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	j := job.NewShellJob("echo foo", "")
-	s.Require().NoError(j.Lock("taken"))
+	s.Require().NoError(j.Lock("taken", amboy.LockTimeout))
 
 	s.NoError(s.driver.Put(s.ctx, j))
 	s.Equal(1, s.driver.Stats(s.ctx).Total)

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/grip"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,9 +35,9 @@ func TestDriverSuiteWithMongoDBInstance(t *testing.T) {
 	tests.uuid = uuid.New().String()
 	opts := DefaultMongoDBOptions()
 	opts.DB = "amboy_test"
-	mDriver := newMongoDriver(
-		"test-"+tests.uuid,
-		opts).(*mongoDriver)
+	driver, err := newMongoDriver("test-"+tests.uuid, opts)
+	require.NoError(t, err)
+	mDriver := driver.(*mongoDriver)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -271,15 +272,12 @@ func (s *DriverSuite) TestStatsMethodReturnsAllJobs() {
 
 func (s *DriverSuite) TestReturnsDefaultLockTimeout() {
 	s.Equal(amboy.LockTimeout, s.driver.LockTimeout())
-	d, ok := s.driver.(*mongoDriver)
-	s.Require().True(ok)
-	s.Equal(amboy.LockTimeout, d.opts.GetLockTimeout())
 }
 
 func (s *DriverSuite) TestInfoReturnsConfigurableLockTimeout() {
 	opts := DefaultMongoDBOptions()
 	opts.LockTimeout = 25 * time.Minute
-	d := newMongoDriver(s.T().Name(), opts)
+	d, err := newMongoDriver(s.T().Name(), opts)
+	s.Require().NoError(err)
 	s.Equal(opts.LockTimeout, d.LockTimeout())
-	s.Equal(opts.LockTimeout, opts.GetLockTimeout())
 }

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -269,7 +269,17 @@ func (s *DriverSuite) TestStatsMethodReturnsAllJobs() {
 	s.Equal(counter, 30)
 }
 
-// kim: TODO: write test
-// func (s *DriverSuite) TestInfoReturnsConfigurableLockTimeout() {
-//     s.driver.LockTimeout()
-// }
+func (s *DriverSuite) TestReturnsDefaultLockTimeout() {
+	s.Equal(amboy.LockTimeout, s.driver.LockTimeout())
+	d, ok := s.driver.(*mongoDriver)
+	s.Require().True(ok)
+	s.Equal(amboy.LockTimeout, d.opts.GetLockTimeout())
+}
+
+func (s *DriverSuite) TestInfoReturnsConfigurableLockTimeout() {
+	opts := DefaultMongoDBOptions()
+	opts.LockTimeout = 25 * time.Minute
+	d := newMongoDriver(s.T().Name(), opts)
+	s.Equal(opts.LockTimeout, d.LockTimeout())
+	s.Equal(opts.LockTimeout, opts.GetLockTimeout())
+}

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -192,6 +192,16 @@ func (q *limitedSizeLocal) Started() bool {
 	return q.channel != nil
 }
 
+func (q *limitedSizeLocal) Info() amboy.QueueInfo {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	return amboy.QueueInfo{
+		Started:     q.channel != nil,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 // Results is a generator of all completed tasks in the queue.
 func (q *limitedSizeLocal) Results(ctx context.Context) <-chan amboy.Job {
 	q.mu.Lock()

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -63,7 +63,7 @@ func (q *limitedSizeLocal) ID() string {
 // stored in the results storage,) or is pending, and finally if the
 // queue is at capacity.
 func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.Errorf("queue not open. could not add %s", j.ID())
 	}
 
@@ -94,7 +94,7 @@ func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
 }
 
 func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.Errorf("queue not open. could not add %s", j.ID())
 	}
 
@@ -181,15 +181,6 @@ func (q *limitedSizeLocal) requeue(job amboy.Job) {
 	case <-q.lifetimeCtx.Done():
 	case q.channel <- job:
 	}
-}
-
-// Started returns true if the queue is open and is processing jobs,
-// and false otherwise.
-func (q *limitedSizeLocal) Started() bool {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-
-	return q.channel != nil
 }
 
 func (q *limitedSizeLocal) Info() amboy.QueueInfo {

--- a/queue/fixed_test.go
+++ b/queue/fixed_test.go
@@ -43,13 +43,13 @@ func (s *LimitedSizeQueueSuite) TestBufferForPendingWorkEqualToCapacityForResult
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.queue.Runner().Close(ctx)
 	s.Nil(s.queue.channel)
 	s.Error(s.queue.Put(ctx, job.NewShellJob("sleep 10", "")))
 
 	s.NoError(s.queue.Start(ctx))
-	s.require.True(s.queue.Started())
+	s.require.True(s.queue.Info().Started)
 	for i := 0; i < 100*s.numCapacity*s.numWorkers; i++ {
 		var outcome bool
 		err := s.queue.Put(ctx, job.NewShellJob("sleep 10", ""))
@@ -72,7 +72,7 @@ func (s *LimitedSizeQueueSuite) TestBufferForPendingWorkEqualToCapacityForResult
 }
 
 func (s *LimitedSizeQueueSuite) TestCallingStartMultipleTimesDoesNotImpactState() {
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.Nil(s.queue.channel)
 	ctx := context.Background()
 	s.NoError(s.queue.Start(ctx))
@@ -89,17 +89,17 @@ func (s *LimitedSizeQueueSuite) TestCannotSetRunnerAfterQueueIsOpened() {
 	secondRunner := pool.NewSingle()
 	runner := s.queue.runner
 
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	for i := 0; i < 25; i++ {
 		s.NoError(s.queue.SetRunner(secondRunner))
 		s.NoError(s.queue.SetRunner(runner))
 	}
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 
 	ctx := context.Background()
 	s.NoError(s.queue.Start(ctx))
 
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	for i := 0; i < 30; i++ {
 		s.Error(s.queue.SetRunner(secondRunner))

--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -331,12 +331,12 @@ func TestQueueGroup(t *testing.T) {
 					q1, err := g.Get(ctx, "one")
 					require.NoError(t, err)
 					require.NotNil(t, q1)
-					require.True(t, q1.Started())
+					require.True(t, q1.Info().Started)
 
 					q2, err := g.Get(ctx, "two")
 					require.NoError(t, err)
 					require.NotNil(t, q2)
-					require.True(t, q2.Started())
+					require.True(t, q2.Info().Started)
 
 					j1 := job.NewShellJob("true", "")
 					j2 := job.NewShellJob("true", "")
@@ -397,28 +397,28 @@ func TestQueueGroup(t *testing.T) {
 					q1, err := g.Get(ctx, "one")
 					require.NoError(t, err)
 					require.NotNil(t, q1)
-					if !q1.Started() {
+					if !q1.Info().Started {
 						require.NoError(t, q1.Start(ctx))
 					}
 
 					q2, err := localConstructor(ctx)
 					require.NoError(t, err)
 					require.Error(t, g.Put(ctx, "one", q2), "cannot add queue to existing index")
-					if !q2.Started() {
+					if !q2.Info().Started {
 						require.NoError(t, q2.Start(ctx))
 					}
 
 					q3, err := localConstructor(ctx)
 					require.NoError(t, err)
 					require.NoError(t, g.Put(ctx, "three", q3))
-					if !q3.Started() {
+					if !q3.Info().Started {
 						require.NoError(t, q3.Start(ctx))
 					}
 
 					q4, err := localConstructor(ctx)
 					require.NoError(t, err)
 					require.NoError(t, g.Put(ctx, "four", q4))
-					if !q4.Started() {
+					if !q4.Info().Started {
 						require.NoError(t, q4.Start(ctx))
 					}
 

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -154,7 +154,7 @@ func (q *depGraphOrderedLocal) Runner() amboy.Runner {
 // implementations at run time. This method fails if the runner has
 // started.
 func (q *depGraphOrderedLocal) SetRunner(r amboy.Runner) error {
-	if q.Started() {
+	if q.Info().Started {
 		return errors.New("cannot change runners after starting")
 	}
 
@@ -162,13 +162,10 @@ func (q *depGraphOrderedLocal) SetRunner(r amboy.Runner) error {
 	return nil
 }
 
-// Started returns true when the Queue has begun dispatching tasks to
-// runners.
-func (q *depGraphOrderedLocal) Started() bool {
-	return q.started
-}
-
 func (q *depGraphOrderedLocal) Info() amboy.QueueInfo {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
 	return amboy.QueueInfo{
 		Started:     q.started,
 		LockTimeout: amboy.LockTimeout,
@@ -312,7 +309,7 @@ func (q *depGraphOrderedLocal) buildGraph() error {
 // Start starts the runner worker processes organizes the graph and
 // begins dispatching jobs to the workers.
 func (q *depGraphOrderedLocal) Start(ctx context.Context) error {
-	if q.started {
+	if q.Info().Started {
 		return nil
 	}
 

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -168,6 +168,13 @@ func (q *depGraphOrderedLocal) Started() bool {
 	return q.started
 }
 
+func (q *depGraphOrderedLocal) Info() amboy.QueueInfo {
+	return amboy.QueueInfo{
+		Started:     q.started,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 // Next returns a job from the Queue. This call is non-blocking. If
 // there are no pending jobs at the moment, then Next returns an
 // error.

--- a/queue/ordered_test.go
+++ b/queue/ordered_test.go
@@ -111,9 +111,9 @@ func (s *OrderedQueueSuite) TestInternalRunnerCannotBeChangedAfterStartingAQueue
 	defer cancel()
 
 	runner := s.queue.Runner()
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	newRunner := pool.NewLocalWorkers(2, s.queue)
 	s.Error(s.queue.SetRunner(newRunner))
@@ -143,17 +143,17 @@ func (s *OrderedQueueSuite) TestQueueCanOnlyBeStartedOnce() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	amboy.Wait(ctx, s.queue)
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	// you can call start more than once until the queue has
 	// completed
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 }
 
 func (s *OrderedQueueSuite) TestPassedIsCompletedButDoesNotRun() {

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -125,6 +125,13 @@ func (q *priorityLocalQueue) Started() bool {
 	return q.channel != nil
 }
 
+func (q *priorityLocalQueue) Info() amboy.QueueInfo {
+	return amboy.QueueInfo{
+		Started:     q.channel != nil,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 // Results is a generator of all jobs that report as "Completed" in
 // the queue.
 func (q *priorityLocalQueue) Results(ctx context.Context) <-chan amboy.Job {

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -120,11 +120,6 @@ func (q *priorityLocalQueue) Next(ctx context.Context) amboy.Job {
 	}
 }
 
-// Started reports if the queue has begun processing work.
-func (q *priorityLocalQueue) Started() bool {
-	return q.channel != nil
-}
-
 func (q *priorityLocalQueue) Info() amboy.QueueInfo {
 	return amboy.QueueInfo{
 		Started:     q.channel != nil,
@@ -188,7 +183,7 @@ func (q *priorityLocalQueue) Runner() amboy.Runner {
 // you attempt to set the runner after the queue has started the
 // operation returns an error and has no effect.
 func (q *priorityLocalQueue) SetRunner(r amboy.Runner) error {
-	if q.Started() {
+	if q.Info().Started {
 		return errors.New("cannot set runner after queue is started")
 	}
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -466,14 +466,14 @@ func TestQueueSmoke(t *testing.T) {
 								require.NoError(t, q.Start(ctx))
 								require.NoError(t, q.Put(ctx, j))
 
-								require.NoError(t, j.Lock(q.ID()))
+								require.NoError(t, j.Lock(q.ID(), q.Info().LockTimeout))
 								require.NoError(t, q.Save(ctx, j))
 
 								if test.IsRemote {
 									// this errors because you can't save if you've double-locked,
 									// but only real remote drivers check locks.
-									require.NoError(t, j.Lock(q.ID()))
-									require.NoError(t, j.Lock(q.ID()))
+									require.NoError(t, j.Lock(q.ID(), q.Info().LockTimeout))
+									require.NoError(t, j.Lock(q.ID(), q.Info().LockTimeout))
 									require.Error(t, q.Save(ctx, j))
 								}
 
@@ -481,7 +481,7 @@ func TestQueueSmoke(t *testing.T) {
 									var ok bool
 									j, ok = q.Get(ctx, j.ID())
 									require.True(t, ok)
-									require.NoError(t, j.Lock(q.ID()))
+									require.NoError(t, j.Lock(q.ID(), q.Info().LockTimeout))
 									require.NoError(t, q.Save(ctx, j))
 								}
 

--- a/queue/remote.go
+++ b/queue/remote.go
@@ -49,9 +49,15 @@ func (opts *MongoDBQueueCreationOptions) build(ctx context.Context) (amboy.Queue
 
 	if opts.Client == nil {
 		if opts.MDB.UseGroups {
-			driver = newMongoGroupDriver(opts.Name, opts.MDB, opts.MDB.GroupName)
+			driver, err = newMongoGroupDriver(opts.Name, opts.MDB, opts.MDB.GroupName)
+			if err != nil {
+				return nil, errors.Wrap(err, "problem creating group driver")
+			}
 		} else {
-			driver = newMongoDriver(opts.Name, opts.MDB)
+			driver, err = newMongoDriver(opts.Name, opts.MDB)
+			if err != nil {
+				return nil, errors.Wrap(err, "problem creating driver")
+			}
 		}
 
 		err = driver.Open(ctx)

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -168,9 +168,9 @@ func (s *RemoteUnorderedSuite) TestInternalRunnerCannotBeChangedAfterStartingAQu
 	s.NoError(s.queue.SetDriver(s.driver))
 
 	runner := s.queue.Runner()
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	newRunner := pool.NewLocalWorkers(2, s.queue)
 	s.Error(s.queue.SetRunner(newRunner))
@@ -244,7 +244,7 @@ func (s *RemoteUnorderedSuite) TestStartMethodCanBeCalledMultipleTimes() {
 	s.NoError(s.queue.SetDriver(s.driver))
 	for i := 0; i < 200; i++ {
 		s.NoError(s.queue.Start(ctx))
-		s.True(s.queue.Started())
+		s.True(s.queue.Info().Started)
 	}
 }
 

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -348,3 +348,15 @@ func (s *RemoteUnorderedSuite) TestTimeInfoPersists() {
 	j2 := s.queue.Next(ctx)
 	s.NotZero(j2.TimeInfo())
 }
+
+func (s *RemoteUnorderedSuite) TestInfoReturnsDefaultLockTimeout() {
+	s.Equal(amboy.LockTimeout, s.queue.Info().LockTimeout)
+}
+
+func (s *RemoteUnorderedSuite) TestInfoReturnsConfigurableLockTimeout() {
+	opts := DefaultMongoDBOptions()
+	opts.LockTimeout = 30 * time.Minute
+	d := newMongoDriver(s.T().Name(), opts)
+	s.Require().NoError(s.queue.SetDriver(d))
+	s.Equal(opts.LockTimeout, s.queue.Info().LockTimeout)
+}

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -263,10 +263,10 @@ func (s *RemoteUnorderedSuite) TestNextMethodSkipsLockedJobs() {
 
 		if i%3 == 0 {
 			numLocked++
-			err := j.Lock(s.driver.ID())
+			err := j.Lock(s.driver.ID(), amboy.LockTimeout)
 			s.NoError(err)
 
-			s.Error(j.Lock("elsewhere"))
+			s.Error(j.Lock("elsewhere", amboy.LockTimeout))
 			lockedJobs[j.ID()] = struct{}{}
 		}
 

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -356,7 +356,8 @@ func (s *RemoteUnorderedSuite) TestInfoReturnsDefaultLockTimeout() {
 func (s *RemoteUnorderedSuite) TestInfoReturnsConfigurableLockTimeout() {
 	opts := DefaultMongoDBOptions()
 	opts.LockTimeout = 30 * time.Minute
-	d := newMongoDriver(s.T().Name(), opts)
+	d, err := newMongoDriver(s.T().Name(), opts)
+	s.Require().NoError(err)
 	s.Require().NoError(s.queue.SetDriver(d))
 	s.Equal(opts.LockTimeout, s.queue.Info().LockTimeout)
 }

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -101,7 +101,7 @@ func (q *shuffledLocal) reactor(ctx context.Context) {
 func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 	id := j.ID()
 
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.Errorf("cannot put job %s; queue not started", id)
 	}
 
@@ -144,7 +144,7 @@ func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 	id := j.ID()
 
-	if !q.Started() {
+	if !q.Info().Started {
 		return errors.Errorf("cannot save job %s; queue not started", id)
 	}
 
@@ -185,7 +185,7 @@ func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 // Get returns a job based on the specified ID. Considers all pending,
 // completed, and in progress jobs.
 func (q *shuffledLocal) Get(ctx context.Context, name string) (amboy.Job, bool) {
-	if !q.Started() {
+	if !q.Info().Started {
 		return nil, false
 	}
 
@@ -228,7 +228,7 @@ func (q *shuffledLocal) Get(ctx context.Context, name string) (amboy.Job, bool) 
 func (q *shuffledLocal) Results(ctx context.Context) <-chan amboy.Job {
 	output := make(chan amboy.Job)
 
-	if !q.Started() {
+	if !q.Info().Started {
 		close(output)
 		return output
 	}
@@ -302,7 +302,7 @@ func (q *shuffledLocal) JobStats(ctx context.Context) <-chan amboy.JobStatusInfo
 // Stats returns a standard report on the number of pending, running,
 // and completed jobs processed by the queue.
 func (q *shuffledLocal) Stats(ctx context.Context) amboy.QueueStats {
-	if !q.Started() {
+	if !q.Info().Started {
 		return amboy.QueueStats{}
 	}
 
@@ -331,13 +331,6 @@ func (q *shuffledLocal) Stats(ctx context.Context) amboy.QueueStats {
 	case out := <-ret:
 		return out
 	}
-}
-
-// Started returns true after the queue has started processing work,
-// and false otherwise. When the queue has terminated (as a result of
-// the starting context's cancellation.
-func (q *shuffledLocal) Started() bool {
-	return q.operations != nil
 }
 
 func (q *shuffledLocal) Info() amboy.QueueInfo {

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -340,6 +340,13 @@ func (q *shuffledLocal) Started() bool {
 	return q.operations != nil
 }
 
+func (q *shuffledLocal) Info() amboy.QueueInfo {
+	return amboy.QueueInfo{
+		Started:     q.operations != nil,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 // Next returns a new pending job, and is used by the Runner interface
 // to fetch new jobs. This method returns a nil job object is there are
 // no pending jobs.

--- a/queue/shuffled_test.go
+++ b/queue/shuffled_test.go
@@ -44,29 +44,29 @@ func (s *ShuffledQueueSuite) TestCannotStartQueueWithNilRunner() {
 
 	// make sure that unstarted queues without runners will error
 	// if you attempt to set them
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.Nil(s.queue.runner)
 	s.Error(s.queue.Start(ctx))
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 
 	// now validate the inverse
 	s.NoError(s.queue.SetRunner(pool.NewSingle()))
 	s.NotNil(s.queue.runner)
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 }
 
 func (s *ShuffledQueueSuite) TestPutFailsWithUnstartedQueue() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	s.Error(s.queue.Put(ctx, job.NewShellJob("echo 1", "")))
 
 	// now validate the inverse
 	s.NoError(s.queue.SetRunner(pool.NewSingle()))
 	s.NoError(s.queue.Start(ctx))
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 
 	s.NoError(s.queue.Put(ctx, job.NewShellJob("echo 1", "")))
 }
@@ -92,7 +92,7 @@ func (s *ShuffledQueueSuite) TestStatsShouldReturnNilObjectifQueueIsNotRunning()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	for i := 0; i < 20; i++ {
 		s.Equal(amboy.QueueStats{}, s.queue.Stats(ctx))
 	}
@@ -140,7 +140,7 @@ func (s *ShuffledQueueSuite) TestGetMethodRetrieves() {
 }
 
 func (s *ShuffledQueueSuite) TestResultsOperationReturnsEmptyChannelIfQueueIsNotStarted() {
-	s.False(s.queue.Started())
+	s.False(s.queue.Info().Started)
 	count := 0
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -203,6 +203,13 @@ func (q *sqsFIFOQueue) Started() bool {
 	return q.started
 }
 
+func (q *sqsFIFOQueue) Info() amboy.QueueInfo {
+	return amboy.QueueInfo{
+		Started:     q.started,
+		LockTimeout: amboy.LockTimeout,
+	}
+}
+
 // Used to mark a Job complete and remove it from the pending
 // work of the queue.
 func (q *sqsFIFOQueue) Complete(ctx context.Context, job amboy.Job) {

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -88,7 +88,7 @@ func (q *sqsFIFOQueue) Put(ctx context.Context, j amboy.Job) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	if !q.Info().Started {
+	if !q.started {
 		return errors.Errorf("cannot put job %s; queue not started", name)
 	}
 
@@ -129,7 +129,7 @@ func (q *sqsFIFOQueue) Save(ctx context.Context, j amboy.Job) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	if !q.Info().Started {
+	if !q.started {
 		return errors.Errorf("cannot save job %s; queue not started", name)
 	}
 

--- a/queue/sqs_test.go
+++ b/queue/sqs_test.go
@@ -71,7 +71,7 @@ func (s *SQSFifoQueueSuite) TestGetMethodReturnsRequestedJob() {
 }
 
 func (s *SQSFifoQueueSuite) TestCannotSetRunnerWhenQueueStarted() {
-	s.True(s.queue.Started())
+	s.True(s.queue.Info().Started)
 	s.Error(s.queue.SetRunner(pool.NewSingle()))
 }
 

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -70,7 +70,7 @@ func (j *JobTest) Error() error {
 	return nil
 }
 
-func (j *JobTest) Lock(id string) error {
+func (j *JobTest) Lock(id string, lockTimeout time.Duration) error {
 	if j.IsLocked {
 		return errors.New("Cannot lock locked job")
 	}
@@ -81,7 +81,7 @@ func (j *JobTest) Lock(id string) error {
 	return nil
 }
 
-func (j *JobTest) Unlock(id string) {
+func (j *JobTest) Unlock(id string, lockTimeout time.Duration) {
 	if !j.IsLocked {
 		return
 	}

--- a/rest/client_queue_test.go
+++ b/rest/client_queue_test.go
@@ -413,7 +413,7 @@ func (s *QueueClientSuite) TestRunningWiwthRunningQueue() {
 	s.client, err = NewQueueClient(s.info.host, s.info.port, "")
 	s.NoError(err)
 
-	s.True(s.service.queue.Started())
+	s.True(s.service.queue.Info().Started)
 
 	running, err := s.client.Running(ctx)
 	s.NoError(err)

--- a/rest/service_queue_stats.go
+++ b/rest/service_queue_stats.go
@@ -22,7 +22,7 @@ func (s *QueueService) getStatus(ctx context.Context) status {
 		SupportedJobTypes: s.registeredTypes,
 	}
 
-	if s.queue != nil && s.queue.Started() {
+	if s.queue != nil && s.queue.Info().Started {
 		output.Status = "ok"
 		output.QueueRunning = true
 		output.PendingJobs = s.queue.Stats(ctx).Pending


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-902

* Add lock timeout setting for mongo driver options.
* Add `Info()` method to `Queue` interface that supercedes `Started()` and returns driver-configurable lock timeout.