### PR TITLE
MAKE-1215: re-dispatch job on lock timeout

### DIFF
--- a/pool/local.go
+++ b/pool/local.go
@@ -68,7 +68,7 @@ func (r *localWorkers) Started() bool {
 }
 
 // Start initializes all worker process, and returns an error if the
-// Runner has already started.
+// Runner does not have a queue.
 func (r *localWorkers) Start(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -47,7 +47,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 		return errors.New("cannot dispatch nil job")
 	}
 
-	if !isDispatchable(job.Status()) {
+	if !isDispatchable(job.Status(), d.queue.Info().LockTimeout) {
 		return errors.New("cannot dispatch in progress or completed job")
 	}
 
@@ -55,9 +55,6 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 	defer d.mutex.Unlock()
 
 	if _, ok := d.cache[job.ID()]; ok {
-		if time.Since(job.Status().ModificationTime) > d.queue.Info().LockTimeout {
-			return errors.New("job is already dispatched")
-		}
 		delete(d.cache, job.ID())
 	}
 

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -820,7 +820,7 @@ RETRY:
 					dispatchSkips++
 					job = nil
 					continue CURSOR
-				} else if d.scopesInUse(ctx, job.Scopes()) && time.Since(job.Status().ModificationTime) <= d.opts.LockTimeout {
+				} else if d.scopesInUse(ctx, job.Scopes()) && !jobCanRestart(job.Status(), d.opts.LockTimeout) {
 					dispatchSkips++
 					job = nil
 					continue CURSOR

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -341,15 +341,12 @@ func (q *remoteBase) canDispatch(j amboy.Job) bool {
 	return true
 }
 
-func isDispatchable(stat amboy.JobStatusInfo) bool {
-	if stat.ModificationTime.Before(time.Now().Add(-amboy.LockTimeout)) {
-		return true
-	}
+func isDispatchable(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
 	if stat.Completed {
 		return false
 	}
 	if stat.InProgress {
-		if time.Since(stat.ModificationTime) > amboy.LockTimeout {
+		if time.Since(stat.ModificationTime) > lockTimeout {
 			return true
 		}
 		return false

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -337,11 +337,11 @@ func (q *remoteBase) canDispatch(j amboy.Job) bool {
 }
 
 func isDispatchable(stat amboy.JobStatusInfo) bool {
-	if stat.Completed {
-		return false
-	}
 	if stat.ModificationTime.Before(time.Now().Add(-amboy.LockTimeout)) {
 		return true
+	}
+	if stat.Completed {
+		return false
 	}
 	if stat.InProgress {
 		return false

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -342,15 +342,19 @@ func (q *remoteBase) canDispatch(j amboy.Job) bool {
 }
 
 func isDispatchable(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
+	if jobCanRestart(stat, lockTimeout) {
+		return true
+	}
 	if stat.Completed {
 		return false
 	}
 	if stat.InProgress {
-		if time.Since(stat.ModificationTime) > lockTimeout {
-			return true
-		}
 		return false
 	}
 
 	return true
+}
+
+func jobCanRestart(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
+	return stat.InProgress && time.Since(stat.ModificationTime) > lockTimeout
 }

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -340,6 +340,9 @@ func isDispatchable(stat amboy.JobStatusInfo) bool {
 	if stat.Completed {
 		return false
 	}
+	if stat.ModificationTime.Before(time.Now().Add(-amboy.LockTimeout)) {
+		return true
+	}
 	if stat.InProgress {
 		return false
 	}

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -98,7 +98,7 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 				})
 
 				if len(edges) == 1 {
-					// this is just an optimization; if there's one dependency its easy
+					// this is just an optimization; if there's one dependency it's easy
 					// to move that job up in the queue by submitting it here.
 					dj, ok := q.Get(ctx, edges[0])
 					if ok && isDispatchable(dj.Status(), q.Info().LockTimeout) {

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -101,7 +101,7 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 					// this is just an optimization; if there's one dependency its easy
 					// to move that job up in the queue by submitting it here.
 					dj, ok := q.Get(ctx, edges[0])
-					if ok && isDispatchable(dj.Status()) {
+					if ok && isDispatchable(dj.Status(), q.Info().LockTimeout) {
 						// might need to make this non-blocking.
 						q.dispatcher.Release(ctx, job)
 						if q.dispatcher.Dispatch(ctx, dj) == nil {

--- a/queue/scope.go
+++ b/queue/scope.go
@@ -20,7 +20,7 @@ type scopeManagerImpl struct {
 }
 
 // NewLocalScopeManager constructs a ScopeManager implementation
-// suitable for use in most local (in memeory) queue implementations.
+// suitable for use in most local (in memory) queue implementations.
 func NewLocalScopeManager() ScopeManager {
 	return &scopeManagerImpl{
 		scopes: map[string]string{},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1215

I'm not entirely confident that this is why barque's scope jobs don't restart when the app server restarts but my current theory is that when the job gets stuck in progress, `(*mongoDriver).getNextQuery()` finds jobs that have exceeded the lock timeout but they get filtered by `isDispatchable()` in `(*dispatcherImpl).Dispatch()`. This just allows jobs that have exceeded the lock timeout. to be re-dispatched.