### PR TITLE
EVG-13538: add option for retryable job

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -144,8 +144,8 @@ type JobTimeInfo struct {
 // JobRetryInfo stores configuration and information for a job that can retry.
 // Support for retrying jobs is optional for Queue implementations.
 type JobRetryInfo struct {
-	Retryable  bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
-	RetryCount int  `bson:"retry_count,omitempty" json:"retry_count,omitempty" yaml:"retry_count,omitempty"`
+	Retryable    bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
+	CurrentTrial int  `bson:"current_trial,omitempty" json:"current_trial,omitempty" yaml:"current_trial,omitempty"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/interface.go
+++ b/interface.go
@@ -31,7 +31,7 @@ type Job interface {
 	// completed state for the job.
 	Run(context.Context)
 
-	// Returns a pointer to a JobType object that Queue
+	// Type returns a JobType object that Queue
 	// implementations can use to de-serialize tasks.
 	Type() JobType
 
@@ -47,12 +47,19 @@ type Job interface {
 	Status() JobStatusInfo
 	SetStatus(JobStatusInfo)
 
-	// TimeInfo reports the start/end time of jobs, as well as
-	// providing for a "wait until" functionality that queues can
-	// use to schedule jobs in the future. The update method, only
-	// updates non-zero methods.
+	// TimeInfo reports the start/end time of jobs, as well as "wait until" and
+	// "dispatch by" options that queues can use to schedule jobs in the future.
+	// UpdateTimeInfo only modifies non-zero fields.
 	TimeInfo() JobTimeInfo
 	UpdateTimeInfo(JobTimeInfo)
+
+	// RetryInfo reports information about the job's retry behavior.
+	// UpdateRetryInfo method only modifies non-zero fields.
+	RetryInfo() JobRetryInfo
+	UpdateRetryInfo(JobRetryInfo)
+	// SetRetryable determines whether or not the job is allowed to retry, which
+	// gives a mechanism to disable retryability after it's enabled.
+	SetRetryable(bool)
 
 	// Provides access to the job's priority value, which some
 	// queues may use to order job dispatching. Most Jobs
@@ -117,7 +124,7 @@ type JobStatusInfo struct {
 // defer the execution of a job, until WaitUntil refers to a time in
 // the past.
 //
-// If the deadline is specified, and the queue
+// If the DispatchBy deadline is specified, and the queue
 // implementation supports it, the queue may drop the job if the
 // deadline is in the past when the job would be dispatched.
 type JobTimeInfo struct {
@@ -127,6 +134,13 @@ type JobTimeInfo struct {
 	WaitUntil  time.Time     `bson:"wait_until" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
 	DispatchBy time.Time     `bson:"dispatch_by" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
 	MaxTime    time.Duration `bson:"max_time" json:"max_time,omitempty" yaml:"max_time,omitempty"`
+}
+
+// JobRetryInfo stores configuration and information for a job that can retry.
+// Support for retrying jobs is optional for Queue implementations.
+type JobRetryInfo struct {
+	Retryable  bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
+	RetryCount int  `bson:"retry_count,omitempty" json:"retry_count,omitempty" yaml:"retry_count,omitempty"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/job/base.go
+++ b/job/base.go
@@ -322,8 +322,8 @@ func (b *Base) UpdateRetryInfo(info amboy.JobRetryInfo) {
 		b.retryInfo.Retryable = true
 	}
 
-	if info.RetryCount != 0 {
-		b.retryInfo.RetryCount = info.RetryCount
+	if info.CurrentTrial != 0 {
+		b.retryInfo.CurrentTrial = info.CurrentTrial
 	}
 }
 

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -142,11 +142,11 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 	s.Require().True(s.base.RetryInfo().Retryable)
 
 	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
-		RetryCount: 5,
+		CurrentTrial: 5,
 	})
 
 	s.Equal(amboy.JobRetryInfo{
-		Retryable:  true,
-		RetryCount: 5,
+		Retryable:    true,
+		CurrentTrial: 5,
 	}, s.base.RetryInfo())
 }

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -121,3 +121,32 @@ func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
 	s.Equal(result.Start, last.Start)
 	s.Equal(result.End, last.End)
 }
+
+func (s *BaseCheckSuite) TestSetRetryable() {
+	s.Require().False(s.base.RetryInfo().Retryable)
+	s.base.SetRetryable(true)
+	s.Require().True(s.base.RetryInfo().Retryable)
+	s.base.SetRetryable(false)
+	s.False(s.base.RetryInfo().Retryable)
+}
+
+func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
+	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
+		Retryable: true,
+	})
+	s.Require().True(s.base.RetryInfo().Retryable)
+
+	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
+		Retryable: false,
+	})
+	s.Require().True(s.base.RetryInfo().Retryable)
+
+	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
+		RetryCount: 5,
+	})
+
+	s.Equal(amboy.JobRetryInfo{
+		Retryable:  true,
+		RetryCount: 5,
+	}, s.base.RetryInfo())
+}

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -19,6 +19,7 @@ type JobInterchange struct {
 	Status     amboy.JobStatusInfo    `bson:"status" json:"status" yaml:"status"`
 	Scopes     []string               `bson:"scopes,omitempty" json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	TimeInfo   amboy.JobTimeInfo      `bson:"time_info" json:"time_info,omitempty" yaml:"time_info,omitempty"`
+	RetryInfo  amboy.JobRetryInfo     `bson:"retry_info,omitempty" json:"retry_info,omitempty" yaml:"retry_info,omitempty"`
 	Job        rawJob                 `json:"job" bson:"job" yaml:"job"`
 	Dependency *DependencyInterchange `json:"dependency,omitempty" bson:"dependency,omitempty" yaml:"dependency,omitempty"`
 }
@@ -49,6 +50,7 @@ func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 		Priority:   j.Priority(),
 		Status:     j.Status(),
 		TimeInfo:   j.TimeInfo(),
+		RetryInfo:  j.RetryInfo(),
 		Job:        data,
 		Dependency: dep,
 	}
@@ -89,6 +91,7 @@ func (j *JobInterchange) Resolve(f amboy.Format) (amboy.Job, error) {
 	job.SetPriority(j.Priority)
 	job.SetStatus(j.Status)
 	job.UpdateTimeInfo(j.TimeInfo)
+	job.UpdateRetryInfo(j.RetryInfo)
 
 	return job, nil
 }

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -170,6 +170,19 @@ func (s *JobInterchangeSuite) TestTimeInfoPersists() {
 
 }
 
+func (s *JobInterchangeSuite) TestRetryInfoPersists() {
+	info := amboy.JobRetryInfo{
+		Retryable:  true,
+		RetryCount: 5,
+	}
+	s.job.UpdateRetryInfo(info)
+	s.Equal(info, s.job.RetryInfo())
+
+	ji, err := MakeJobInterchange(s.job, s.format)
+	s.Require().NoError(err)
+	s.Equal(info, ji.RetryInfo)
+}
+
 // DependencyInterchangeSuite tests the DependencyInterchange format
 // and converters. This type provides a way for Jobs and Queues to
 // serialize their objects quasi-generically.

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -182,8 +182,8 @@ func (s *JobInterchangeSuite) TestApplyScopesOnEnqueuePersists() {
 
 func (s *JobInterchangeSuite) TestRetryInfoPersists() {
 	info := amboy.JobRetryInfo{
-		Retryable:  true,
-		RetryCount: 5,
+		Retryable:    true,
+		CurrentTrial: 5,
 	}
 	s.job.UpdateRetryInfo(info)
 	s.Equal(info, s.job.RetryInfo())

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -28,6 +28,8 @@ type JobTest struct {
 	TimingInfo  amboy.JobTimeInfo   `bson:"time_info" json:"time_info" yaml:"time_info"`
 	LockScopes  []string            `bson:"scopes" json:"scopes" yaml:"scopes"`
 
+	JobRetry amboy.JobRetryInfo
+
 	dep dependency.Manager
 }
 
@@ -143,4 +145,16 @@ func (j *JobTest) SetScopes(in []string) {
 
 func (j *JobTest) Scopes() []string {
 	return j.LockScopes
+}
+
+func (j *JobTest) RetryInfo() amboy.JobRetryInfo {
+	return j.JobRetry
+}
+
+func (j *JobTest) UpdateRetryInfo(info amboy.JobRetryInfo) {
+	j.JobRetry = info
+}
+
+func (j *JobTest) SetRetryable(val bool) {
+	j.JobRetry.Retryable = val
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13538

Implement retryable options with a flag indicating if the job can retry and how many times it's retried. They're no-ops until [EVG-13540](https://jira.mongodb.org/browse/EVG-13540) is implemented to have a retry handler, but they are serialized so they can be stored in MongoDB.