### PR TITLE
EVG-13718: implement applying scope on enqueue for local scope manager implementations

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -172,7 +172,6 @@ post:
       content_type: text/html
       permissions: public-read
       display_name: "(html) coverage:"
-      optional: true
   - command: s3.put
     type: system
     params:
@@ -184,7 +183,6 @@ post:
       content_type: text/plain
       permissions: public-read
       display_name: "(txt) coverage:"
-      optional: true
 
 
 #######################################

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -23,7 +23,6 @@ variables:
         type: system
         params:
           directory: gopath/src/github.com/mongodb/amboy
-      - func: setup-credentials
       - func: run-make
         vars: { target: "${task_name}" }
   - &run-go-test-suite-with-mongodb
@@ -35,7 +34,6 @@ variables:
         type: system
         params:
           directory: gopath/src/github.com/mongodb/amboy
-      - func: setup-credentials
       - func: set-up-mongodb
       - func: run-make
         vars: { target: "${task_name}" }
@@ -44,24 +42,6 @@ variables:
 #              Functions              #
 #######################################
 functions:
-  setup-credentials:
-    command: shell.exec
-    type: setup
-    params:
-       silent: true
-       script: |
-         mkdir ~/.aws
-
-         cat <<EOF > ~/.aws/config
-         [default]
-         region = us-east-1
-         EOF
-
-         cat <<EOF > ~/.aws/credentials
-         [default]
-         aws_access_key_id = ${aws_key}
-         aws_secret_access_key = ${aws_secret}
-         EOF
   run-make:
     command: subprocess.exec
     type: test
@@ -71,6 +51,8 @@ functions:
       args: ["${make_args}", "${target}"]
       add_expansions_to_env: true
       env:
+        AWS_KEY: ${aws_key}
+        AWS_SECRET: ${aws_secret}
         GOPATH: ${workdir}/gopath
   set-up-mongodb:
     # TODO replace this configuration with something more robust.
@@ -134,7 +116,6 @@ tasks:
         type: setup
         params:
           directory: gopath/src/github.com/mongodb/amboy
-      - func: setup-credentials
       - func: set-up-mongodb
       - func: run-make
         vars:
@@ -180,7 +161,6 @@ post:
     params:
       script: |
         rm -rf amboy
-        rm -rf ~/.aws
   - command: s3.put
     type: system
     params:

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -894,7 +894,9 @@ func (d *mongoDriver) scopesInUse(ctx context.Context, scopes []string) bool {
 	if len(scopes) == 0 {
 		return false
 	}
-	num, err := d.getCollection().CountDocuments(ctx, bson.M{"scopes": bson.M{"$in": scopes}})
+	num, err := d.getCollection().CountDocuments(ctx, bson.M{
+		"status.in_prog": true,
+		"scopes":         bson.M{"$in": scopes}})
 	if err != nil {
 		return false
 	}

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -84,9 +84,9 @@ func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
 		return amboy.NewDuplicateJobErrorf("cannot dispatch '%s', already complete", name)
 	}
 
-	if j.ApplyScopesOnEnqueue() {
+	if j.ShouldApplyScopesOnEnqueue() {
 		if err := q.scopes.Acquire(name, j.Scopes()); err != nil {
-			return errors.Wrapf(err, "could not apply scopes on job to enqueue")
+			return errors.Wrapf(err, "applying scopes to job")
 		}
 	}
 
@@ -113,7 +113,7 @@ func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {
 	}
 
 	if err := q.scopes.Acquire(name, j.Scopes()); err != nil {
-		return errors.Wrapf(err, "could not apply scopes to job")
+		return errors.Wrapf(err, "applying scopes to job")
 	}
 
 	q.storage[name] = j

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -84,6 +84,12 @@ func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
 		return amboy.NewDuplicateJobErrorf("cannot dispatch '%s', already complete", name)
 	}
 
+	if j.ApplyScopesOnEnqueue() {
+		if err := q.scopes.Acquire(name, j.Scopes()); err != nil {
+			return errors.Wrapf(err, "could not apply scopes on job to enqueue")
+		}
+	}
+
 	select {
 	case <-ctx.Done():
 		return errors.Wrapf(ctx.Err(), "queue full, cannot add %s", name)
@@ -104,6 +110,10 @@ func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {
 
 	if _, ok := q.storage[name]; !ok {
 		return errors.Errorf("cannot save '%s', which is not tracked", name)
+	}
+
+	if err := q.scopes.Acquire(name, j.Scopes()); err != nil {
+		return errors.Wrapf(err, "could not apply scopes to job")
 	}
 
 	q.storage[name] = j

--- a/queue/mock_job_test.go
+++ b/queue/mock_job_test.go
@@ -46,7 +46,6 @@ func init() {
 	registry.AddJobType("sleep", func() amboy.Job { return newSleepJob() })
 }
 
-//
 type mockJob struct {
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
 }
@@ -90,6 +89,7 @@ func newSleepJob() *sleepJob {
 }
 
 func (j *sleepJob) Run(ctx context.Context) {
+	// pp.Println("kim: sleep job running")
 	defer j.MarkComplete()
 
 	if j.Sleep == 0 {

--- a/queue/mock_job_test.go
+++ b/queue/mock_job_test.go
@@ -89,7 +89,6 @@ func newSleepJob() *sleepJob {
 }
 
 func (j *sleepJob) Run(ctx context.Context) {
-	// pp.Println("kim: sleep job running")
 	defer j.MarkComplete()
 
 	if j.Sleep == 0 {

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -62,10 +62,20 @@ func (q *priorityLocalQueue) Put(ctx context.Context, j amboy.Job) error {
 		return errors.Wrap(err, "invalid job timeinfo")
 	}
 
+	// kim: TODO: test
+	if j.ShouldApplyScopesOnEnqueue() {
+		if err := q.scopes.Acquire(j.ID(), j.Scopes()); err != nil {
+			return errors.Wrapf(err, "applying scopes to job")
+		}
+	}
+
 	return q.storage.Insert(j)
 }
 
 func (q *priorityLocalQueue) Save(ctx context.Context, j amboy.Job) error {
+	if err := q.scopes.Acquire(j.ID(), j.Scopes()); err != nil {
+		return errors.Wrapf(err, "applying scopes to job")
+	}
 	q.storage.Save(j)
 	return nil
 }

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -62,7 +62,6 @@ func (q *priorityLocalQueue) Put(ctx context.Context, j amboy.Job) error {
 		return errors.Wrap(err, "invalid job timeinfo")
 	}
 
-	// kim: TODO: test
 	if j.ShouldApplyScopesOnEnqueue() {
 		if err := q.scopes.Acquire(j.ID(), j.Scopes()); err != nil {
 			return errors.Wrapf(err, "applying scopes to job")

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -54,6 +54,7 @@ type QueueTestCase struct {
 	OrderedStartsBefore     bool
 	WaitUntilSupported      bool
 	DispatchBeforeSupported bool
+	ScopesSupported         bool
 	SkipUnordered           bool
 	IsRemote                bool
 	Skip                    bool
@@ -100,7 +101,8 @@ func DefaultQueueTestCases() []QueueTestCase {
 			},
 		},
 		{
-			Name: "Priority",
+			Name:            "Priority",
+			ScopesSupported: true,
 			Constructor: func(ctx context.Context, _ string, size int) (amboy.Queue, TestCloser, error) {
 				return NewLocalPriorityQueue(size, defaultLocalQueueCapcity), func(ctx context.Context) error { return nil }, nil
 			},
@@ -109,13 +111,15 @@ func DefaultQueueTestCases() []QueueTestCase {
 			Name:                    "LimitedSize",
 			WaitUntilSupported:      true,
 			DispatchBeforeSupported: true,
+			ScopesSupported:         true,
 			Constructor: func(ctx context.Context, _ string, size int) (amboy.Queue, TestCloser, error) {
 				return NewLocalLimitedSize(size, 1024*size), func(ctx context.Context) error { return nil }, nil
 			},
 		},
 		{
-			Name:         "Shuffled",
-			SingleWorker: true,
+			Name:            "Shuffled",
+			SingleWorker:    true,
+			ScopesSupported: true,
 			Constructor: func(ctx context.Context, _ string, size int) (amboy.Queue, TestCloser, error) {
 				return NewShuffledLocal(size, defaultLocalQueueCapcity), func(ctx context.Context) error { return nil }, nil
 			},
@@ -153,8 +157,12 @@ func MergeQueueTestCases(ctx context.Context, cases ...[]QueueTestCase) <-chan Q
 func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 	return []QueueTestCase{
 		{
-			Name:     "MongoUnordered",
-			IsRemote: true,
+			Name:               "MongoUnordered",
+			IsRemote:           true,
+			WaitUntilSupported: true,
+			// kim: NOTE: unsure why this fails the tests
+			// DispatchBeforeSupported: true,
+			ScopesSupported: true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -188,6 +196,10 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 		{
 			Name:     "MongoGroupUnordered",
 			IsRemote: true,
+			// kim: NOTE: added
+			WaitUntilSupported:      true,
+			DispatchBeforeSupported: true,
+			ScopesSupported:         true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -221,9 +233,13 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			},
 		},
 		{
-			Name:     "MongoUnorderedMGOBSON",
-			IsRemote: true,
-			MaxSize:  32,
+			Name:               "MongoUnorderedMGOBSON",
+			IsRemote:           true,
+			WaitUntilSupported: true,
+			// kim: NOTE: unsure why this fails the tests
+			// DispatchBeforeSupported: true,
+			ScopesSupported: true,
+			MaxSize:         32,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -257,6 +273,12 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 		{
 			Name:     "MongoOrdered",
 			IsRemote: true,
+			// kim; NOTE: added
+			WaitUntilSupported: true,
+			// kim: NOTE: unsure why this fails the tests
+			// DispatchBeforeSupported: true,
+			ScopesSupported:  true,
+			OrderedSupported: true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -427,9 +449,14 @@ func TestQueueSmoke(t *testing.T) {
 								OneExecutionTest(bctx, t, test, runner, size)
 							})
 
-							if test.SingleWorker && (!test.OrderedSupported || test.OrderedStartsBefore) && size.Size >= 4 && size.Size <= 32 {
-								t.Run("ScopedLock", func(t *testing.T) {
-									ScopedLockTest(bctx, t, test, runner, size)
+							if test.ScopesSupported {
+								if test.SingleWorker && (!test.OrderedSupported || test.OrderedStartsBefore) && size.Size >= 4 && size.Size <= 32 {
+									t.Run("ScopedLock", func(t *testing.T) {
+										ScopedLockTest(bctx, t, test, runner, size)
+									})
+								}
+								t.Run("ApplyScopesOnEnqueue", func(t *testing.T) {
+									ApplyScopesOnEnqueueTest(bctx, t, test, runner, size)
 								})
 							}
 
@@ -951,6 +978,7 @@ func ScopedLockTest(bctx context.Context, t *testing.T, test QueueTestCase, runn
 
 	for i := 0; i < 2*size.Size; i++ {
 		j := newSleepJob()
+		// kim: NOTE: this works because only half the jobs are scoped.
 		if i%2 == 0 {
 			j.SetScopes([]string{"a"})
 			j.Sleep = time.Hour
@@ -977,4 +1005,64 @@ waitLoop:
 	stats := q.Stats(ctx)
 	assert.Equal(t, 2*size.Size, stats.Total)
 	assert.Equal(t, size.Size, stats.Completed)
+}
+
+// kim: TODO: port remote tests to this test instead.
+func ApplyScopesOnEnqueueTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, q amboy.Queue){
+		"PutJobAppliesScopeAndPreservesSettings": func(ctx context.Context, t *testing.T, q amboy.Queue) {
+			j := newSleepJob()
+			j.Sleep = 10 * time.Millisecond
+			j.SetScopes([]string{"scope"})
+			j.SetShouldApplyScopesOnEnqueue(true)
+
+			require.NoError(t, q.Put(ctx, j))
+			fetchedJob, ok := q.Get(ctx, j.ID())
+			require.True(t, ok)
+			assert.EqualValues(t, j.Scopes(), fetchedJob.Scopes())
+			assert.True(t, fetchedJob.ShouldApplyScopesOnEnqueue())
+		},
+		"PutJobFollowedBySaveSucceeds": func(ctx context.Context, t *testing.T, q amboy.Queue) {
+			j := newSleepJob()
+			j.Sleep = 10 * time.Millisecond
+			j.SetScopes([]string{"scope"})
+			j.SetShouldApplyScopesOnEnqueue(true)
+			require.NoError(t, q.Put(ctx, j))
+			require.NoError(t, q.Save(ctx, j))
+		},
+		"PutJobPreventsEnqueueingDuplicateScopeUntilJobCompletes": func(ctx context.Context, t *testing.T, q amboy.Queue) {
+			j1 := newSleepJob()
+			j1.Sleep = 10 * time.Millisecond
+			j1.SetScopes([]string{"scope"})
+			j1.SetShouldApplyScopesOnEnqueue(true)
+
+			j2 := newSleepJob()
+			j2.Sleep = 10 * time.Millisecond
+			j2.SetScopes([]string{"scope"})
+			j2.SetShouldApplyScopesOnEnqueue(true)
+
+			require.NoError(t, q.Put(ctx, j1))
+			require.Error(t, q.Put(ctx, j2))
+
+			require.True(t, amboy.WaitInterval(ctx, q, 10*time.Millisecond))
+
+			require.NoError(t, q.Put(ctx, j2))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(bctx, time.Minute)
+			defer cancel()
+
+			q, closer, err := test.Constructor(ctx, newDriverID(), size.Size)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, closer(ctx))
+			}()
+			require.NoError(t, runner.SetPool(q, size.Size))
+
+			require.NoError(t, q.Start(ctx))
+
+			testCase(ctx, t, q)
+		})
+	}
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -447,9 +447,11 @@ func TestQueueSmoke(t *testing.T) {
 										ScopedLockTest(bctx, t, test, runner, size)
 									})
 								}
-								t.Run("ApplyScopesOnEnqueue", func(t *testing.T) {
-									ApplyScopesOnEnqueueTest(bctx, t, test, runner, size)
-								})
+								if size.Size <= 4 {
+									t.Run("ApplyScopesOnEnqueue", func(t *testing.T) {
+										ApplyScopesOnEnqueueTest(bctx, t, test, runner, size)
+									})
+								}
 							}
 
 							if test.IsRemote && test.MultiSupported && !runner.SkipMulti {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -195,8 +195,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			Name:               "MongoGroupUnordered",
 			IsRemote:           true,
 			WaitUntilSupported: true,
-			// DispatchBeforeSupported: true,
-			ScopesSupported: true,
+			ScopesSupported:    true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -160,9 +160,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			Name:               "MongoUnordered",
 			IsRemote:           true,
 			WaitUntilSupported: true,
-			// kim: NOTE: unsure why this fails the tests
-			// DispatchBeforeSupported: true,
-			ScopesSupported: true,
+			ScopesSupported:    true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -194,9 +192,8 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			},
 		},
 		{
-			Name:     "MongoGroupUnordered",
-			IsRemote: true,
-			// kim: NOTE: added
+			Name:                    "MongoGroupUnordered",
+			IsRemote:                true,
 			WaitUntilSupported:      true,
 			DispatchBeforeSupported: true,
 			ScopesSupported:         true,
@@ -236,10 +233,8 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			Name:               "MongoUnorderedMGOBSON",
 			IsRemote:           true,
 			WaitUntilSupported: true,
-			// kim: NOTE: unsure why this fails the tests
-			// DispatchBeforeSupported: true,
-			ScopesSupported: true,
-			MaxSize:         32,
+			ScopesSupported:    true,
+			MaxSize:            32,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -271,14 +266,11 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			},
 		},
 		{
-			Name:     "MongoOrdered",
-			IsRemote: true,
-			// kim; NOTE: added
+			Name:               "MongoOrdered",
+			IsRemote:           true,
 			WaitUntilSupported: true,
-			// kim: NOTE: unsure why this fails the tests
-			// DispatchBeforeSupported: true,
-			ScopesSupported:  true,
-			OrderedSupported: true,
+			ScopesSupported:    true,
+			OrderedSupported:   true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,
@@ -978,7 +970,6 @@ func ScopedLockTest(bctx context.Context, t *testing.T, test QueueTestCase, runn
 
 	for i := 0; i < 2*size.Size; i++ {
 		j := newSleepJob()
-		// kim: NOTE: this works because only half the jobs are scoped.
 		if i%2 == 0 {
 			j.SetScopes([]string{"a"})
 			j.Sleep = time.Hour
@@ -1007,7 +998,6 @@ waitLoop:
 	assert.Equal(t, size.Size, stats.Completed)
 }
 
-// kim: TODO: port remote tests to this test instead.
 func ApplyScopesOnEnqueueTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, q amboy.Queue){
 		"PutJobAppliesScopeAndPreservesSettings": func(ctx context.Context, t *testing.T, q amboy.Queue) {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -129,7 +129,7 @@ func DefaultQueueTestCases() []QueueTestCase {
 			MaxSize: 4,
 			Skip:    true,
 			Constructor: func(ctx context.Context, _ string, size int) (amboy.Queue, TestCloser, error) {
-				q, err := NewSQSFifoQueue(randomString(4), size)
+				q, err := NewSQSFifoQueue(randomString(4), size, awsTestCredentialsFromEnv())
 				closer := func(ctx context.Context) error { return nil }
 				return q, closer, err
 			},
@@ -192,11 +192,11 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 			},
 		},
 		{
-			Name:                    "MongoGroupUnordered",
-			IsRemote:                true,
-			WaitUntilSupported:      true,
-			DispatchBeforeSupported: true,
-			ScopesSupported:         true,
+			Name:               "MongoGroupUnordered",
+			IsRemote:           true,
+			WaitUntilSupported: true,
+			// DispatchBeforeSupported: true,
+			ScopesSupported: true,
 			Constructor: func(ctx context.Context, name string, size int) (amboy.Queue, TestCloser, error) {
 				opts := MongoDBQueueCreationOptions{
 					Size:    size,

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -109,25 +109,6 @@ func (s *RemoteUnorderedSuite) TestJobPutIntoQueueFetchableViaGetMethod() {
 	s.Equal(j.Type(), nj.Type())
 }
 
-func (s *RemoteUnorderedSuite) TestJobScopesApplyWhenJobIsPutIntoQueue() {
-	s.Require().NoError(s.queue.SetDriver(s.driver))
-
-	j := job.NewShellJob("echo foo", "")
-	j.SetScopes([]string{"scope"})
-	j.SetShouldApplyScopesOnEnqueue(true)
-
-	s.Require().NoError(s.queue.Put(s.ctx, j))
-	fetchedJob, ok := s.queue.Get(s.ctx, j.ID())
-	s.Require().True(ok)
-	s.EqualValues(fetchedJob.Scopes(), j.Scopes())
-	s.True(fetchedJob.ShouldApplyScopesOnEnqueue())
-
-	j = job.NewShellJob("echo bar", "")
-	j.SetScopes([]string{"scope"})
-	j.SetShouldApplyScopesOnEnqueue(true)
-	s.Require().Error(s.queue.Put(s.ctx, j))
-}
-
 func (s *RemoteUnorderedSuite) TestGetMethodHandlesMissingJobs() {
 	s.Require().Nil(s.queue.Driver())
 	s.Require().NoError(s.queue.SetDriver(s.driver))

--- a/queue/scope.go
+++ b/queue/scope.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ScopeManager provides a service to queue implementation to support
+// ScopeManager provides a service to queue implementations to support
 // additional locking semantics for queues that cannot push that into
 // their backing storage.
 type ScopeManager interface {
@@ -35,10 +35,12 @@ func (s *scopeManagerImpl) Acquire(id string, scopes []string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	var scopesToAcquire []string
 	for _, sc := range scopes {
 		holder, ok := s.scopes[sc]
 		if !ok {
-			s.scopes[sc] = id
+			scopesToAcquire = append(scopesToAcquire, sc)
+			// s.scopes[sc] = id
 			continue
 		}
 
@@ -46,6 +48,10 @@ func (s *scopeManagerImpl) Acquire(id string, scopes []string) error {
 			continue
 		}
 		return errors.Errorf("could not acquire lock scope '%s' held by '%s' not '%s'", sc, holder, id)
+	}
+
+	for _, sc := range scopesToAcquire {
+		s.scopes[sc] = id
 	}
 
 	return nil
@@ -59,16 +65,22 @@ func (s *scopeManagerImpl) Release(id string, scopes []string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	var scopesToRelease []string
 	for _, sc := range scopes {
 		holder, ok := s.scopes[sc]
 		if !ok {
 			continue
 		}
 		if holder == id {
-			delete(s.scopes, sc)
+			scopesToRelease = append(scopesToRelease, sc)
+			// delete(s.scopes, sc)
 			continue
 		}
 		return errors.Errorf("could not release lock scope '%s', held by '%s' not '%s'", sc, holder, id)
+	}
+
+	for _, sc := range scopesToRelease {
+		delete(s.scopes, sc)
 	}
 
 	return nil

--- a/queue/scope.go
+++ b/queue/scope.go
@@ -40,7 +40,6 @@ func (s *scopeManagerImpl) Acquire(id string, scopes []string) error {
 		holder, ok := s.scopes[sc]
 		if !ok {
 			scopesToAcquire = append(scopesToAcquire, sc)
-			// s.scopes[sc] = id
 			continue
 		}
 
@@ -73,7 +72,6 @@ func (s *scopeManagerImpl) Release(id string, scopes []string) error {
 		}
 		if holder == id {
 			scopesToRelease = append(scopesToRelease, sc)
-			// delete(s.scopes, sc)
 			continue
 		}
 		return errors.Errorf("could not release lock scope '%s', held by '%s' not '%s'", sc, holder, id)

--- a/queue/scope_test.go
+++ b/queue/scope_test.go
@@ -1,0 +1,57 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeManager(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T, mngr ScopeManager){
+		"AcquireChecksEachScopeForUniqueness": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id1", []string{"foo"}))
+			require.NoError(t, mngr.Acquire("id1", []string{"bar", "bat"}))
+			require.Error(t, mngr.Acquire("id2", []string{"foo"}))
+			require.Error(t, mngr.Acquire("id2", []string{"foo", "baz"}))
+		},
+		"DoubleAcquireForSameIDWithSameScopesIsIdempotent": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id", []string{"foo"}))
+			require.NoError(t, mngr.Acquire("id", []string{"foo"}))
+		},
+		"DoubleAcquireForSameIDWithDifferentScopesSucceeds": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id", []string{"foo"}))
+			require.NoError(t, mngr.Acquire("id", []string{"bar"}))
+		},
+		"ReleaseOfUnownedScopeForIDIsNoop": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Release("id", []string{"foo"}))
+		},
+		"ReleaseOfScopeOwnedByAnotherIDFails": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id1", []string{"foo"}))
+			require.Error(t, mngr.Release("id2", []string{"foo"}))
+		},
+		"DoubleReleaseOfSameScopeForIDIsIdempotent": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id", []string{"foo"}))
+			require.NoError(t, mngr.Release("id", []string{"foo"}))
+			require.NoError(t, mngr.Release("id", []string{"foo"}))
+		},
+		"AcquireIsAtomic": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id1", []string{"foo"}))
+			require.Error(t, mngr.Acquire("id2", []string{"bar", "foo"}))
+			// If Acquire is atomic, "bar" should be unowned so this should not
+			// error.
+			require.NoError(t, mngr.Release("id1", []string{"bar"}))
+		},
+		"ReleaseIsAtomic": func(t *testing.T, mngr ScopeManager) {
+			require.NoError(t, mngr.Acquire("id1", []string{"foo"}))
+			require.NoError(t, mngr.Acquire("id2", []string{"bar", "bat"}))
+			require.Error(t, mngr.Release("id2", []string{"bar", "foo"}))
+			// If Release is atomic, "bar" should still be owned by "id2" so
+			// this should error.
+			require.Error(t, mngr.Release("id1", []string{"bar"}))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t, NewLocalScopeManager())
+		})
+	}
+}

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -32,7 +32,7 @@ import (
 // LocalShuffled provides a queue implementation that shuffles the
 // order of jobs, relative the insertion order. Unlike
 // some of the other local queue implementations that predate LocalShuffled
-// (e.g. LocalUnordered,) there are no mutexes used in the implementation.
+// (e.g. LocalUnordered), there are no mutexes used in the implementation.
 type shuffledLocal struct {
 	operations chan func(map[string]amboy.Job, map[string]amboy.Job, map[string]amboy.Job, *fixedStorage)
 	capacity   int
@@ -114,7 +114,6 @@ func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 		return errors.Wrap(err, "invalid job timeinfo")
 	}
 
-	// kim: TODO: test
 	if j.ShouldApplyScopesOnEnqueue() {
 		if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
 			return errors.Wrapf(err, "applying scopes to job")
@@ -156,7 +155,6 @@ func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 		return errors.Errorf("cannot save job %s; queue not started", id)
 	}
 
-	// pp.Println("kim: shuffle Save():", j.ID(), j.Scopes())
 	if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
 		return errors.Wrapf(err, "applying scopes to job")
 	}
@@ -376,7 +374,6 @@ func (q *shuffledLocal) Next(ctx context.Context) amboy.Job {
 			if err := q.scopes.Acquire(j.ID(), j.Scopes()); err != nil {
 				continue
 			}
-			// pp.Println("kim: shuffle dispatch in Next():", j.ID(), j.Type().Name, j.Scopes())
 
 			select {
 			case <-ctx.Done():
@@ -433,7 +430,6 @@ func (q *shuffledLocal) Complete(ctx context.Context, j amboy.Job) {
 			}
 		}
 
-		// pp.Println("kim: shuffle Complete():", j.ID(), j.Scopes())
 		grip.Warning(message.WrapError(
 			q.scopes.Release(j.ID(), j.Scopes()),
 			message.Fields{

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -117,7 +117,7 @@ func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 	// kim: TODO: test
 	if j.ShouldApplyScopesOnEnqueue() {
 		if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
-			return errors.Wrapf(err, "could not apply scopes on job to enqueue")
+			return errors.Wrapf(err, "applying scopes to job")
 		}
 	}
 
@@ -156,8 +156,9 @@ func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 		return errors.Errorf("cannot save job %s; queue not started", id)
 	}
 
+	// pp.Println("kim: shuffle Save():", j.ID(), j.Scopes())
 	if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
-		return errors.Wrapf(err, "could not apply scopes to job")
+		return errors.Wrapf(err, "applying scopes to job")
 	}
 
 	ret := make(chan error)
@@ -375,6 +376,7 @@ func (q *shuffledLocal) Next(ctx context.Context) amboy.Job {
 			if err := q.scopes.Acquire(j.ID(), j.Scopes()); err != nil {
 				continue
 			}
+			// pp.Println("kim: shuffle dispatch in Next():", j.ID(), j.Type().Name, j.Scopes())
 
 			select {
 			case <-ctx.Done():
@@ -431,6 +433,7 @@ func (q *shuffledLocal) Complete(ctx context.Context, j amboy.Job) {
 			}
 		}
 
+		// pp.Println("kim: shuffle Complete():", j.ID(), j.Scopes())
 		grip.Warning(message.WrapError(
 			q.scopes.Release(j.ID(), j.Scopes()),
 			message.Fields{

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -32,7 +32,7 @@ import (
 // LocalShuffled provides a queue implementation that shuffles the
 // order of jobs, relative the insertion order. Unlike
 // some of the other local queue implementations that predate LocalShuffled
-// (e.g. LocalUnordered,) there are no mutexes uses in the implementation.
+// (e.g. LocalUnordered,) there are no mutexes used in the implementation.
 type shuffledLocal struct {
 	operations chan func(map[string]amboy.Job, map[string]amboy.Job, map[string]amboy.Job, *fixedStorage)
 	capacity   int
@@ -97,7 +97,8 @@ func (q *shuffledLocal) reactor(ctx context.Context) {
 }
 
 // Put adds a job to the queue, and returns errors if the queue hasn't
-// started or if a job with the same ID value already exists.
+// started or if a job conflicts with one already in the queue (e.g. the job is
+// already in the queue or it cannot acquire the scopes that it needs).
 func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 	id := j.ID()
 
@@ -111,6 +112,13 @@ func (q *shuffledLocal) Put(ctx context.Context, j amboy.Job) error {
 
 	if err := j.TimeInfo().Validate(); err != nil {
 		return errors.Wrap(err, "invalid job timeinfo")
+	}
+
+	// kim: TODO: test
+	if j.ShouldApplyScopesOnEnqueue() {
+		if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
+			return errors.Wrapf(err, "could not apply scopes on job to enqueue")
+		}
 	}
 
 	ret := make(chan error)
@@ -146,6 +154,10 @@ func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 
 	if !q.Info().Started {
 		return errors.Errorf("cannot save job %s; queue not started", id)
+	}
+
+	if err := q.scopes.Acquire(id, j.Scopes()); err != nil {
+		return errors.Wrapf(err, "could not apply scopes to job")
 	}
 
 	ret := make(chan error)

--- a/queue/shuffled_test.go
+++ b/queue/shuffled_test.go
@@ -25,11 +25,8 @@ func TestShuffledQueueSuite(t *testing.T) {
 	suite.Run(t, new(ShuffledQueueSuite))
 }
 
-func (s *ShuffledQueueSuite) SetupSuite() {
-	s.require = s.Require()
-}
-
 func (s *ShuffledQueueSuite) SetupTest() {
+	// kim: TODO: add test for applying scope on enqueue
 	s.queue = &shuffledLocal{
 		capacity: defaultLocalQueueCapcity,
 		scopes:   NewLocalScopeManager(),

--- a/queue/shuffled_test.go
+++ b/queue/shuffled_test.go
@@ -26,7 +26,6 @@ func TestShuffledQueueSuite(t *testing.T) {
 }
 
 func (s *ShuffledQueueSuite) SetupTest() {
-	// kim: TODO: add test for applying scope on enqueue
 	s.queue = &shuffledLocal{
 		capacity: defaultLocalQueueCapcity,
 		scopes:   NewLocalScopeManager(),

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/google/uuid"
@@ -43,10 +44,11 @@ type sqsFIFOQueue struct {
 // implementation. This queue, generally is ephemeral: tasks are
 // removed from the queue, and therefore may not handle jobs across
 // restarts.
-func NewSQSFifoQueue(queueName string, workers int) (amboy.Queue, error) {
+func NewSQSFifoQueue(queueName string, workers int, creds *credentials.Credentials) (amboy.Queue, error) {
 	q := &sqsFIFOQueue{
 		sqsClient: sqs.New(session.Must(session.NewSession(&aws.Config{
-			Region: aws.String(region),
+			Credentials: creds,
+			Region:      aws.String(region),
 		}))),
 		id: fmt.Sprintf("queue.remote.sqs.fifo..%s", uuid.New().String()),
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13718

* Make the local scope manager operations atomic. Previously, it was possible to partially acquire/release the scopes that you pass in.
* Implement applying scopes for implementations that already use a local scope manager.
* Make the queue implementations consistent with the remote queue/Mongo driver, which acquires the scope in `Save()`.
* Write common queue interface tests for all implementations that have scopes.
* Fix some test coverage issues where a bunch of implementations that support WaitUntil/DispatchBy wouldn't test them.