### PR TITLE
EVG-13760: cancel the job's context after MaxTime elapses

### DIFF
--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -797,9 +797,6 @@ waitLoop:
 	assert.Equal(t, size.Size, stats.Completed)
 }
 
-/* kim: TODO: test
-- 5 second sleep job with MaxTime of 1 second, let it run and check that time is less than 5 seconds.
-*/
 func MaxTimeTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
 	ctx, cancel := context.WithTimeout(bctx, 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13760

MaxTime currently does nothing if you set it except set an error message after the job completes. It should now behave as expected and cancel the job's `Run()` context after MaxTime (which must be configured before the job has been enqueued).