### PR TITLE
EVG-13545: add option for job that needs to retry

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -35,6 +35,8 @@ imports:
   version: afeadc9b9f628ce2a9d11a7e5b25dac8a0970727
 - name: github.com/evergreen-ci/poplar
   version: 952cf7a06a66d844a5450c6db6802faeb0f1a72e
+- name: github.com/evergreen-ci/utility
+  version: aaeb41d8ac416e8989f5d3175d2c2b607bed1aed
 
 - name: go.mongodb.org/mongo-driver
   version: 305bc4a5e4131420fe8ba5628e6faa9e6ade4e86

--- a/interface.go
+++ b/interface.go
@@ -54,12 +54,9 @@ type Job interface {
 	UpdateTimeInfo(JobTimeInfo)
 
 	// RetryInfo reports information about the job's retry behavior.
-	// UpdateRetryInfo method only modifies non-zero fields.
 	RetryInfo() JobRetryInfo
-	UpdateRetryInfo(JobRetryInfo)
-	// SetRetryable determines whether or not the job is allowed to retry, which
-	// gives a mechanism to disable retryability after it's enabled.
-	SetRetryable(bool)
+	// UpdateRetryInfo method modifies all set fields from the given options.
+	UpdateRetryInfo(JobRetryOptions)
 
 	// Provides access to the job's priority value, which some
 	// queues may use to order job dispatching. Most Jobs
@@ -144,8 +141,36 @@ type JobTimeInfo struct {
 // JobRetryInfo stores configuration and information for a job that can retry.
 // Support for retrying jobs is optional for Queue implementations.
 type JobRetryInfo struct {
-	Retryable    bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
-	CurrentTrial int  `bson:"current_trial,omitempty" json:"current_trial,omitempty" yaml:"current_trial,omitempty"`
+	// Retryable indicates whether the job should use Amboy's built-in retry
+	// mechanism.
+	Retryable bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
+	// NeedsRetry indicates whether the job is supposed to retry when it is
+	// complete. This will only be considered if Retryable is true.
+	NeedsRetry bool `bson:"needs_retry,omitempty" json:"needs_retry,omitempty" yaml:"needs_retry,omitempty"`
+	// CurrentTrial is the current attempt number. This is zero-indexed, so the
+	// first time the job attempts to run, its value is 0. Each subsequent retry
+	// increments this value.
+	CurrentTrial int `bson:"current_trial,omitempty" json:"current_trial,omitempty" yaml:"current_trial,omitempty"`
+}
+
+// Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other
+// words, if the returned result is used with Job.UpdateRetryInfo(), the job
+// will have the same JobRetryInfo as this one.
+func (info *JobRetryInfo) Options() JobRetryOptions {
+	return JobRetryOptions{
+		Retryable:    &info.Retryable,
+		NeedsRetry:   &info.NeedsRetry,
+		CurrentTrial: &info.CurrentTrial,
+	}
+}
+
+// JobRetryOptions represents configuration options for a job that can retry.
+// Their meaning corresponds to the fields in JobRetryInfo, but is more amenable
+// to optional input values.
+type JobRetryOptions struct {
+	Retryable    *bool `bson:"-" json:"-" yaml:"-"`
+	NeedsRetry   *bool `bson:"-" json:"-" yaml:"-"`
+	CurrentTrial *int  `bson:"-" json:"-" yaml:"-"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/interface.go
+++ b/interface.go
@@ -143,10 +143,10 @@ type JobTimeInfo struct {
 type JobRetryInfo struct {
 	// Retryable indicates whether the job should use Amboy's built-in retry
 	// mechanism.
-	Retryable bool `bson:"retryable,omitempty" json:"retryable,omitempty" yaml:"retryable,omitempty"`
+	Retryable bool `bson:"retryable" json:"retryable,omitempty" yaml:"retryable,omitempty"`
 	// NeedsRetry indicates whether the job is supposed to retry when it is
 	// complete. This will only be considered if Retryable is true.
-	NeedsRetry bool `bson:"needs_retry,omitempty" json:"needs_retry,omitempty" yaml:"needs_retry,omitempty"`
+	NeedsRetry bool `bson:"needs_retry" json:"needs_retry,omitempty" yaml:"needs_retry,omitempty"`
 	// CurrentTrial is the current attempt number. This is zero-indexed, so the
 	// first time the job attempts to run, its value is 0. Each subsequent retry
 	// increments this value.

--- a/interface.go
+++ b/interface.go
@@ -57,9 +57,6 @@ type Job interface {
 	RetryInfo() JobRetryInfo
 	// UpdateRetryInfo method modifies all set fields from the given options.
 	UpdateRetryInfo(JobRetryOptions)
-	// SetRetryable is a convenience function to indicate that a job will
-	// support retrying.
-	SetRetryable(bool)
 
 	// Provides access to the job's priority value, which some
 	// queues may use to order job dispatching. Most Jobs

--- a/interface.go
+++ b/interface.go
@@ -57,6 +57,9 @@ type Job interface {
 	RetryInfo() JobRetryInfo
 	// UpdateRetryInfo method modifies all set fields from the given options.
 	UpdateRetryInfo(JobRetryOptions)
+	// SetRetryable is a convenience function to indicate that a job will
+	// support retrying.
+	SetRetryable(bool)
 
 	// Provides access to the job's priority value, which some
 	// queues may use to order job dispatching. Most Jobs

--- a/job/base.go
+++ b/job/base.go
@@ -320,20 +320,9 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.Retryable != nil {
 		b.retryInfo.Retryable = *opts.Retryable
 	}
-	// kim: NOTE:
-	// If this is default false when the job goes in the queue:
-	// - Inserting into the queue, it'll be true.
-	// - At the end of the job, if a retryable error has been added
-	// (AddRetryableError), NeedsRetry will be true
-	// - If the job marks itself as retryable manually with SetNeedsRetry,
-	// NeedsRetry will be true.
-	// - Jobs that are stuck in progress will be caught by the stranded job
-	// handling mechanism in the MongoDB driver (i.e.  `getNextQuery` looks for
-	// `stats.in_prog = true`, which).
 	if opts.NeedsRetry != nil {
 		b.retryInfo.NeedsRetry = *opts.NeedsRetry
 	}
-
 	if opts.CurrentTrial != nil {
 		b.retryInfo.CurrentTrial = *opts.CurrentTrial
 	}

--- a/job/base.go
+++ b/job/base.go
@@ -327,13 +327,3 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 		b.retryInfo.CurrentTrial = *opts.CurrentTrial
 	}
 }
-
-// SetRetryable marks the job as one that will retry, without any additional
-// configuration.
-func (b *Base) SetRetryable(val bool) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	b.retryInfo.Retryable = val
-	b.retryInfo.NeedsRetry = val
-}

--- a/job/base.go
+++ b/job/base.go
@@ -327,3 +327,13 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 		b.retryInfo.CurrentTrial = *opts.CurrentTrial
 	}
 }
+
+// SetRetryable marks the job as one that will retry, without any additional
+// configuration.
+func (b *Base) SetRetryable(val bool) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.retryInfo.Retryable = val
+	b.retryInfo.NeedsRetry = val
+}

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -123,7 +123,8 @@ func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
 }
 
 func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
-	// kim: TODO: use utility value-to-pointer methods
+	// TODO (EVG-13920): use utility methods rather than make pointers like
+	// this.
 	trueVal := true
 	falseVal := false
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/stretchr/testify/require"
@@ -123,12 +124,8 @@ func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
 }
 
 func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
-	// TODO (EVG-13920): use utility methods rather than make pointers like
-	// this.
-	trueVal := true
-	falseVal := false
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		Retryable: &trueVal,
+		Retryable: utility.TruePtr(),
 	})
 	s.Require().Equal(amboy.JobRetryInfo{
 		Retryable: true,
@@ -136,7 +133,7 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 
 	trial := 5
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		CurrentTrial: &trial,
+		CurrentTrial: utility.ToIntPtr(trial),
 	})
 
 	s.Require().Equal(amboy.JobRetryInfo{
@@ -145,14 +142,14 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		Retryable: &falseVal,
+		Retryable: utility.FalsePtr(),
 	})
 	s.Require().Equal(amboy.JobRetryInfo{
 		CurrentTrial: trial,
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		NeedsRetry: &trueVal,
+		NeedsRetry: utility.TruePtr(),
 	})
 
 	s.Require().Equal(amboy.JobRetryInfo{

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -122,31 +122,40 @@ func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
 	s.Equal(result.End, last.End)
 }
 
-func (s *BaseCheckSuite) TestSetRetryable() {
-	s.Require().False(s.base.RetryInfo().Retryable)
-	s.base.SetRetryable(true)
-	s.Require().True(s.base.RetryInfo().Retryable)
-	s.base.SetRetryable(false)
-	s.False(s.base.RetryInfo().Retryable)
-}
-
 func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
-	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
+	// kim: TODO: use utility value-to-pointer methods
+	trueVal := true
+	falseVal := false
+	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable: &trueVal,
+	})
+	s.Require().Equal(amboy.JobRetryInfo{
 		Retryable: true,
-	})
-	s.Require().True(s.base.RetryInfo().Retryable)
+	}, s.base.RetryInfo())
 
-	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
-		Retryable: false,
-	})
-	s.Require().True(s.base.RetryInfo().Retryable)
-
-	s.base.UpdateRetryInfo(amboy.JobRetryInfo{
-		CurrentTrial: 5,
+	trial := 5
+	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
+		CurrentTrial: &trial,
 	})
 
-	s.Equal(amboy.JobRetryInfo{
+	s.Require().Equal(amboy.JobRetryInfo{
 		Retryable:    true,
-		CurrentTrial: 5,
+		CurrentTrial: trial,
+	}, s.base.RetryInfo())
+
+	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable: &falseVal,
+	})
+	s.Require().Equal(amboy.JobRetryInfo{
+		CurrentTrial: trial,
+	}, s.base.RetryInfo())
+
+	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
+		NeedsRetry: &trueVal,
+	})
+
+	s.Require().Equal(amboy.JobRetryInfo{
+		NeedsRetry:   true,
+		CurrentTrial: trial,
 	}, s.base.RetryInfo())
 }

--- a/makefile
+++ b/makefile
@@ -141,6 +141,10 @@ vendor-clean:
 	rm -rf vendor/github.com/evergreen-ci/poplar/vendor/github.com/evergreen-ci/pail/vendor/github.com/aws/aws-sdk-go/
 	rm -rf vendor/github.com/evergreen-ci/poplar/vendor/github.com/mongodb/amboy/
 	rm -rf vendor/github.com/evergreen-ci/poplar/vendor/github.com/mongodb/grip/
+	rm -rf vendor/github.com/evergreen-ci/utility/file.go
+	rm -rf vendor/github.com/evergreen-ci/utility/http.go
+	rm -rf vendor/github.com/evergreen-ci/utility/network.go
+	rm -rf vendor/github.com/evergreen-ci/utility/parsing.go
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
 	rm -rf vendor/gopkg.in/mgo.v2/harness/

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -19,7 +19,7 @@ type JobInterchange struct {
 	Status               amboy.JobStatusInfo    `bson:"status" json:"status" yaml:"status"`
 	Scopes               []string               `bson:"scopes,omitempty" json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	ApplyScopesOnEnqueue bool                   `bson:"apply_scopes_on_enqueue" json:"apply_scopes_on_enqueue,omitempty" yaml:"apply_scopes_on_enqueue,omitempty"`
-	RetryInfo            amboy.JobRetryInfo     `bson:"retry_info,omitempty" json:"retry_info,omitempty" yaml:"retry_info,omitempty"`
+	RetryInfo            amboy.JobRetryInfo     `bson:"retry_info" json:"retry_info,omitempty" yaml:"retry_info,omitempty"`
 	TimeInfo             amboy.JobTimeInfo      `bson:"time_info" json:"time_info,omitempty" yaml:"time_info,omitempty"`
 	Job                  rawJob                 `json:"job" bson:"job" yaml:"job"`
 	Dependency           *DependencyInterchange `json:"dependency,omitempty" bson:"dependency,omitempty" yaml:"dependency,omitempty"`

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -94,7 +94,7 @@ func (j *JobInterchange) Resolve(f amboy.Format) (amboy.Job, error) {
 	job.SetStatus(j.Status)
 	job.SetShouldApplyScopesOnEnqueue(j.ApplyScopesOnEnqueue)
 	job.UpdateTimeInfo(j.TimeInfo)
-	job.UpdateRetryInfo(j.RetryInfo)
+	job.UpdateRetryInfo(j.RetryInfo.Options())
 
 	return job, nil
 }

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -185,7 +185,7 @@ func (s *JobInterchangeSuite) TestRetryInfoPersists() {
 		Retryable:    true,
 		CurrentTrial: 5,
 	}
-	s.job.UpdateRetryInfo(info)
+	s.job.UpdateRetryInfo(info.Options())
 	s.Equal(info, s.job.RetryInfo())
 
 	ji, err := MakeJobInterchange(s.job, s.format)

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -29,7 +29,7 @@ type JobTest struct {
 	LockScopes           []string            `bson:"scopes" json:"scopes" yaml:"scopes"`
 	ApplyScopesOnEnqueue bool                `bson:"apply_scopes_on_enqueue" json:"apply_scopes_on_enqueue" yaml:"apply_scopes_on_enqueue"`
 
-	JobRetry amboy.JobRetryInfo
+	Retry amboy.JobRetryInfo
 
 	dep dependency.Manager
 }
@@ -157,13 +157,17 @@ func (j *JobTest) ShouldApplyScopesOnEnqueue() bool {
 }
 
 func (j *JobTest) RetryInfo() amboy.JobRetryInfo {
-	return j.JobRetry
+	return j.Retry
 }
 
-func (j *JobTest) UpdateRetryInfo(info amboy.JobRetryInfo) {
-	j.JobRetry = info
-}
-
-func (j *JobTest) SetRetryable(val bool) {
-	j.JobRetry.Retryable = val
+func (j *JobTest) UpdateRetryInfo(opts amboy.JobRetryOptions) {
+	if opts.Retryable != nil {
+		j.Retry.Retryable = *opts.Retryable
+	}
+	if opts.NeedsRetry != nil {
+		j.Retry.NeedsRetry = *opts.NeedsRetry
+	}
+	if opts.CurrentTrial != nil {
+		j.Retry.CurrentTrial = *opts.CurrentTrial
+	}
 }

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -171,8 +171,3 @@ func (j *JobTest) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 		j.Retry.CurrentTrial = *opts.CurrentTrial
 	}
 }
-
-func (j *JobTest) SetRetryable(val bool) {
-	j.Retry.Retryable = val
-	j.Retry.NeedsRetry = val
-}

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -171,3 +171,8 @@ func (j *JobTest) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 		j.Retry.CurrentTrial = *opts.CurrentTrial
 	}
 }
+
+func (j *JobTest) SetRetryable(val bool) {
+	j.Retry.Retryable = val
+	j.Retry.NeedsRetry = val
+}

--- a/vendor/github.com/evergreen-ci/utility/checksum.go
+++ b/vendor/github.com/evergreen-ci/utility/checksum.go
@@ -1,0 +1,45 @@
+package utility
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// ChecksumFile returns the checksum of a file given by path using the given
+// hash.
+func ChecksumFile(hash hash.Hash, path string) (string, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "file '%s' does not exist", path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "problem opening '%s'", path)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(hash, f)
+	if err != nil {
+		return "", errors.Wrap(err, "problem hashing contents")
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+// MD5SumFile is the same as ChecksumFile using MD5 as the checksum.
+func MD5SumFile(path string) (string, error) {
+	out, err := ChecksumFile(md5.New(), path)
+	return out, errors.WithStack(err)
+}
+
+// SHA1SumFile is the same as ChecksumFile using SHA1 as the checksum.
+func SHA1SumFile(path string) (string, error) {
+	out, err := ChecksumFile(sha1.New(), path)
+	return out, errors.WithStack(err)
+}

--- a/vendor/github.com/evergreen-ci/utility/checksum_test.go
+++ b/vendor/github.com/evergreen-ci/utility/checksum_test.go
@@ -1,0 +1,64 @@
+package utility
+
+import (
+	"crypto"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksumFile(t *testing.T) {
+	if usr, _ := user.Current(); usr == nil || usr.Username == "root" {
+		t.Skip("test assumes not root")
+	}
+	_, file, _, _ := runtime.Caller(1)
+
+	for name, hash := range map[string]crypto.Hash{
+		"MD5":    crypto.MD5,
+		"SHA512": crypto.SHA512,
+		"SHA1":   crypto.SHA1,
+		"SHA256": crypto.SHA256,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Run("NoFile", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), "")
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileIsNotReadable", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), "/root/.bashrc")
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileIsDirectory", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), filepath.Dir(file))
+				assert.Error(t, err)
+				assert.Zero(t, out)
+			})
+			t.Run("FileExists", func(t *testing.T) {
+				out, err := ChecksumFile(hash.New(), file)
+				assert.NoError(t, err)
+				assert.NotZero(t, out)
+			})
+		})
+	}
+	t.Run("NilHash", func(t *testing.T) {
+		assert.Panics(t, func() {
+			out, err := ChecksumFile(nil, file)
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		})
+	})
+	t.Run("ChecksumFrontends", func(t *testing.T) {
+		out, err := MD5SumFile(file)
+		assert.NoError(t, err)
+		assert.NotZero(t, out)
+
+		out, err = SHA1SumFile(file)
+		assert.NoError(t, err)
+		assert.NotZero(t, out)
+	})
+}

--- a/vendor/github.com/evergreen-ci/utility/file_test.go
+++ b/vendor/github.com/evergreen-ci/utility/file_test.go
@@ -1,0 +1,260 @@
+package utility
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFile(t *testing.T) {
+	t.Run("FileExistence", func(t *testing.T) {
+		defer func() { assert.NoError(t, os.RemoveAll("foo")) }()
+		require.False(t, FileExists("foo"))
+		require.NoError(t, WriteFile("foo", "hello world"))
+		require.True(t, FileExists("foo"))
+	})
+	t.Run("WriteFile", func(t *testing.T) {
+		defer func() { assert.NoError(t, os.RemoveAll("foo")) }()
+		require.Error(t, WriteFile("/usr/local", "hi"))
+		require.NoError(t, WriteFile("foo", "hello world"))
+	})
+}
+
+func TestFileListBuilder(t *testing.T) {
+	t.Run("DoesNotPanicForMissingRoot", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			dir := "this/path/does/not/exist"
+			m, err := NewGitignoreFileMatcher(dir, "*")
+			require.NoError(t, err)
+			b := FileListBuilder{
+				WorkingDir: dir,
+				Include:    m,
+			}
+			files, err := b.Build()
+			require.Error(t, err)
+			assert.Empty(t, files)
+		})
+	})
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	fileNames := []string{
+		"testFile1",
+		"testFile2",
+		"testFile1.go",
+		"testFile2.go",
+		"testFile3.yml",
+		"built.yml",
+		"built.go",
+		"built.cpp",
+	}
+	dirNames := []string{
+		"dir1",
+		"dir2",
+	}
+
+	var allFiles []string
+
+	for _, fileName := range fileNames {
+		f, err := os.Create(filepath.Join(tmpDir, fileName))
+		require.NoError(t, err, "error creating test file")
+		require.NoError(t, f.Close(), "error closing test file")
+		allFiles = append(allFiles, fileName)
+	}
+
+	for _, dirName := range dirNames {
+		err := os.Mkdir(filepath.Join(tmpDir, dirName), 0777)
+		require.NoError(t, err, "error creating test directory")
+		for _, fileName := range fileNames {
+			path := filepath.Join(tmpDir, dirName, fileName)
+			f, err := os.Create(path)
+			require.NoError(t, err, "error creating test file")
+			require.NoError(t, f.Close(), "error closing test file")
+			allFiles = append(allFiles, filepath.Join(dirName, fileName))
+		}
+	}
+
+	t.Run("GitignoreFileBuilder", func(t *testing.T) {
+		for testName, testCase := range map[string]struct {
+			includeExprs []string
+			excludeExprs []string
+			expected     []string
+		}{
+			"MatchesOneFileName": {
+				includeExprs: []string{"testFile1"},
+				expected: []string{
+					"testFile1",
+					filepath.Join("dir1", "testFile1"),
+					filepath.Join("dir2", "testFile1"),
+				},
+			},
+			"MatchesOneFileWhenSubdirectoriesExcluded": {
+				includeExprs: []string{"testFile1"},
+				excludeExprs: []string{"/*/testFile1"},
+				expected:     []string{"testFile1"},
+			},
+			"MatchesAllFilesWithPrefix": {
+				includeExprs: []string{"/testFile*"},
+				expected: []string{
+					"testFile1",
+					"testFile2",
+					"testFile1.go",
+					"testFile2.go",
+					"testFile3.yml",
+				},
+			},
+			"MatchesAllFilesWithPrefixExcludingSuffix": {
+				includeExprs: []string{"/testFile*"},
+				excludeExprs: []string{"/*.go"},
+				expected: []string{
+					"testFile1",
+					"testFile2",
+					"testFile3.yml",
+				},
+			},
+			"MatchesAllFilesWithSuffix": {
+				includeExprs: []string{"/*.go"},
+				expected: []string{
+					"testFile1.go",
+					"testFile2.go",
+					"built.go",
+				},
+			},
+			"MatchesAllFilesWithSuffixExcludingPrefix": {
+				includeExprs: []string{"/*.go"},
+				excludeExprs: []string{"/built*"},
+				expected: []string{
+					"testFile1.go",
+					"testFile2.go",
+				},
+			},
+			"MatchesAllFilesInSubdirectoryWithSuffix": {
+				includeExprs: []string{"/dir1/*.go"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir1", "built.go"),
+				},
+			},
+			"MatchesAllFilesInWildcardSubdirectoryWithSuffix": {
+				includeExprs: []string{"/*/*.go"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir1", "built.go"),
+					filepath.Join("dir2", "testFile1.go"),
+					filepath.Join("dir2", "testFile2.go"),
+					filepath.Join("dir2", "built.go"),
+				},
+			},
+			"MatchesAllFilesInWildcardSubdirectoryWithSuffixExcludingPrefix": {
+				includeExprs: []string{"/*/*.go"},
+				excludeExprs: []string{"/*/built*"},
+				expected: []string{
+					filepath.Join("dir1", "testFile1.go"),
+					filepath.Join("dir1", "testFile2.go"),
+					filepath.Join("dir2", "testFile1.go"),
+					filepath.Join("dir2", "testFile2.go"),
+				},
+			},
+		} {
+			t.Run(testName, func(t *testing.T) {
+				include, err := NewGitignoreFileMatcher(tmpDir, testCase.includeExprs...)
+				require.NoError(t, err)
+				var exclude FileMatcher
+				if len(testCase.excludeExprs) != 0 {
+					exclude, err = NewGitignoreFileMatcher(tmpDir, testCase.excludeExprs...)
+					require.NoError(t, err)
+				}
+				b := FileListBuilder{
+					WorkingDir: tmpDir,
+					Include:    include,
+					Exclude:    exclude,
+				}
+
+				files, err := b.Build()
+				require.NoError(t, err)
+				assert.ElementsMatch(t, testCase.expected, files)
+			})
+		}
+	})
+
+	t.Run("NewFileListBuilder", func(t *testing.T) {
+		t.Run("MatchesAllFiles", func(t *testing.T) {
+			b := NewFileListBuilder(tmpDir)
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, allFiles, files)
+		})
+	})
+	t.Run("AlwaysMatch", func(t *testing.T) {
+		t.Run("IncludesAllFilesAndDirectories", func(t *testing.T) {
+			b := NewFileListBuilder(tmpDir)
+			b.Include = AlwaysMatch{}
+			files, err := b.Build()
+			require.NoError(t, err)
+			allFilesAndDirs := append(allFiles, dirNames...)
+			allFilesAndDirs = append(allFilesAndDirs, "")
+			assert.ElementsMatch(t, allFilesAndDirs, files)
+		})
+		t.Run("ExcludesAllFilesAndDirectories", func(t *testing.T) {
+			b := NewFileListBuilder(tmpDir)
+			b.Exclude = AlwaysMatch{}
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.Empty(t, files)
+		})
+	})
+
+	t.Run("FileAlwaysMatch", func(t *testing.T) {
+		t.Run("IncludesAllFiles", func(t *testing.T) {
+			b := FileListBuilder{
+				Include:    FileAlwaysMatch{},
+				WorkingDir: tmpDir,
+			}
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, allFiles, files)
+		})
+		t.Run("ExcludesAllFiles", func(t *testing.T) {
+			b := FileListBuilder{
+				Include:    AlwaysMatch{},
+				Exclude:    FileAlwaysMatch{},
+				WorkingDir: tmpDir,
+			}
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, append(dirNames, ""), files)
+		})
+	})
+
+	t.Run("NeverMatch", func(t *testing.T) {
+		t.Run("IncludesNoFiles", func(t *testing.T) {
+			b := FileListBuilder{
+				Include:    NeverMatch{},
+				WorkingDir: tmpDir,
+			}
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.Empty(t, files)
+		})
+		t.Run("ExcludesNoFiles", func(t *testing.T) {
+			b := FileListBuilder{
+				Include:    FileAlwaysMatch{},
+				Exclude:    NeverMatch{},
+				WorkingDir: tmpDir,
+			}
+			files, err := b.Build()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, allFiles, files)
+		})
+	})
+}

--- a/vendor/github.com/evergreen-ci/utility/http_test.go
+++ b/vendor/github.com/evergreen-ci/utility/http_test.go
@@ -1,0 +1,103 @@
+package utility
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/rehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestPooledHTTPClient(t *testing.T) {
+	t.Run("Initialized", func(t *testing.T) {
+		require.NotNil(t, httpClientPool)
+		cl := GetHTTPClient()
+		require.NotNil(t, cl)
+		require.NotPanics(t, func() { PutHTTPClient(cl) })
+	})
+	t.Run("ResettingSkipCert", func(t *testing.T) {
+		cl := GetHTTPClient()
+		cl.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+		PutHTTPClient(cl)
+		cl2 := GetHTTPClient()
+		assert.Equal(t, cl, cl2)
+		assert.False(t, cl.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+		assert.False(t, cl2.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+	})
+	t.Run("RehttpPool", func(t *testing.T) {
+		initHTTPPool()
+		cl := GetHTTPClient()
+		clt := cl.Transport
+		PutHTTPClient(cl)
+		rcl := GetDefaultHTTPRetryableClient()
+		assert.Equal(t, cl, rcl)
+		assert.NotEqual(t, clt, rcl.Transport)
+		assert.Equal(t, clt, rcl.Transport.(*rehttp.Transport).RoundTripper)
+	})
+}
+
+type mockTransport struct {
+	count         int
+	expectedToken string
+	status        int
+}
+
+func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.count++
+
+	resp := http.Response{
+		StatusCode: t.status,
+		Header:     http.Header{},
+		Body:       ioutil.NopCloser(strings.NewReader("hi")),
+	}
+
+	token := req.Header.Get("Authorization")
+	split := strings.Split(token, " ")
+	if len(split) != 2 || split[0] != "Bearer" || split[1] != t.expectedToken {
+		resp.StatusCode = http.StatusForbidden
+	}
+	return &resp, nil
+}
+
+func TestRetryableOauthClient(t *testing.T) {
+	t.Run("Passing", func(t *testing.T) {
+		c := GetOauth2DefaultHTTPRetryableClient("hi")
+		defer PutHTTPClient(c)
+
+		transport := &mockTransport{expectedToken: "hi", status: http.StatusOK}
+		oldTransport := c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper
+		defer func() {
+			c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper = oldTransport
+		}()
+		c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper = transport
+
+		resp, err := c.Get("https://example.com")
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, 1, transport.count)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+	t.Run("Failed", func(t *testing.T) {
+		conf := NewDefaultHTTPRetryConf()
+		conf.MaxRetries = 5
+		c := GetOauth2HTTPRetryableClient("hi", conf)
+		defer PutHTTPClient(c)
+
+		transport := &mockTransport{expectedToken: "hi", status: http.StatusInternalServerError}
+		oldTransport := c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper
+		defer func() {
+			c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper = oldTransport
+		}()
+		c.Transport.(*oauth2.Transport).Base.(*rehttp.Transport).RoundTripper = transport
+
+		resp, err := c.Get("https://example.com")
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, 6, transport.count)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+}

--- a/vendor/github.com/evergreen-ci/utility/io.go
+++ b/vendor/github.com/evergreen-ci/utility/io.go
@@ -1,0 +1,15 @@
+package utility
+
+import "io"
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error { return nil }
+
+// NopWriteCloser returns a WriteCloser with a no-op Close method wrapping
+// the provided writer w.
+func NopWriteCloser(w io.Writer) io.WriteCloser {
+	return nopWriteCloser{w}
+}

--- a/vendor/github.com/evergreen-ci/utility/io_test.go
+++ b/vendor/github.com/evergreen-ci/utility/io_test.go
@@ -1,0 +1,32 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNopWriteCloser(t *testing.T) {
+	wc := &myWriteCloser{}
+	nop := NopWriteCloser(wc)
+	nop.Close()
+	assert.False(t, wc.closed)
+
+	message := []byte("message")
+	_, err := nop.Write(message)
+	assert.Equal(t, message, wc.contents)
+	assert.NoError(t, err)
+}
+
+type myWriteCloser struct {
+	closed   bool
+	contents []byte
+}
+
+func (w *myWriteCloser) Close() {
+	w.closed = true
+}
+func (w *myWriteCloser) Write(p []byte) (n int, err error) {
+	w.contents = append(w.contents, p...)
+	return 0, nil
+}

--- a/vendor/github.com/evergreen-ci/utility/network_test.go
+++ b/vendor/github.com/evergreen-ci/utility/network_test.go
@@ -1,0 +1,19 @@
+package utility
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkFinder(t *testing.T) {
+	addr, err := GetPublicIP()
+	require.NoError(t, err)
+	require.NotZero(t, addr)
+
+	assert.True(t, !strings.HasPrefix(addr, "127"))
+	assert.True(t, !strings.HasPrefix(addr, "172.16"))
+	assert.True(t, len(addr) <= 15)
+}

--- a/vendor/github.com/evergreen-ci/utility/optional.go
+++ b/vendor/github.com/evergreen-ci/utility/optional.go
@@ -1,0 +1,174 @@
+package utility
+
+import "time"
+
+// This file includes conversion functions for using pointers as optional
+// values.
+
+// TruePtr returns a pointer to a true value.
+func TruePtr() *bool {
+	res := true
+	return &res
+}
+
+// FalsePtr returns a pointer to a false value.
+func FalsePtr() *bool {
+	res := false
+	return &res
+}
+
+// ToBoolPtr returns a pointer to a bool value.
+func ToBoolPtr(in bool) *bool {
+	return &in
+}
+
+// FromBoolPtr returns the resolved boolean value from the input boolean
+// pointer. For nil pointers, it returns false (i.e. the default value is false
+// when the boolean is unspecified).
+func FromBoolPtr(in *bool) bool {
+	if in == nil {
+		return false
+	}
+	return *in
+}
+
+// FromBoolTPtr returns the resolved boolean value from the input boolean
+// pointer. For nil pointers, it returns true (i.e. the default value is true
+// when the boolean is unspecified).
+func FromBoolTPtr(in *bool) bool {
+	if in == nil {
+		return true
+	}
+	return *in
+}
+
+// ToIntPtr returns a pointer to an int value.
+func ToIntPtr(in int) *int {
+	return &in
+}
+
+// FromIntPtr returns the resolved int value from the input int pointer. For nil
+// pointers, it returns 0.
+func FromIntPtr(in *int) int {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToUintPtr returns a pointer to a uint value.
+func ToUintPtr(in uint) *uint {
+	return &in
+}
+
+// FromUintPtr returns the resolved uint value from the input uint pointer. For
+// nil pointers, it returns 0.
+func FromUintPtr(in *uint) uint {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToBytePtr returns a pointer to a byte value.
+func ToBytePtr(in byte) *byte {
+	return &in
+}
+
+// FromBytePtr returns the resolved byte value from the input byte pointer. For
+// nil pointers, it returns 0.
+func FromBytePtr(in *byte) byte {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToFloat64Ptr returns a pointer to a float64 value.
+func ToFloat64Ptr(in float64) *float64 {
+	return &in
+}
+
+// FromFloat64Ptr returns the resolved float64 value from the input float64
+// pointer. For nil pointers, it returns 0.
+func FromFloat64Ptr(in *float64) float64 {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToFloat32Ptr returns a pointer to a float32 value.
+func ToFloat32Ptr(in float32) *float32 {
+	return &in
+}
+
+// FromFloat32Ptr returns the resolved float32 value from the input float32
+// pointer. For nil pointers, it returns 0.
+func FromFloat32Ptr(in *float32) float32 {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToTimeDurationPtr returns a pointer to a time.Duration value.
+func ToTimeDurationPtr(in time.Duration) *time.Duration {
+	return &in
+}
+
+// FromTimeDurationPtr returns the resolved time.Duration value from the input
+// time.Duration pointer. For nil pointers, it returns time.Duration(0).
+func FromTimeDurationPtr(in *time.Duration) time.Duration {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToTimePtr returns a pointer to a time.Time value.
+func ToTimePtr(in time.Time) *time.Time {
+	return &in
+}
+
+// FromTimePtr returns the resolved time.Time value from the input time.Time
+// pointer. For nil pointers, it returns the zero time.
+func FromTimePtr(in *time.Time) time.Time {
+	if in == nil {
+		return time.Time{}
+	}
+	return *in
+}
+
+// ToStringPtr returns a pointer to a string.
+func ToStringPtr(in string) *string {
+	return &in
+}
+
+// FromStringPtr returns the resolved string value from the input string
+// pointer. For nil pointers, it returns the empty string.
+func FromStringPtr(in *string) string {
+	if in == nil {
+		return ""
+	}
+	return *in
+}
+
+// ToStringPtr returns a slice of string pointers from a slice of strings.
+func ToStringPtrSlice(in []string) []*string {
+	var res []*string
+	for _, each := range in {
+		res = append(res, ToStringPtr(each))
+	}
+	return res
+}
+
+// FromStringPtrSlice returns a slice of strings from a slice of string
+// pointers.
+func FromStringPtrSlice(in []*string) []string {
+	var res []string
+	for _, each := range in {
+		res = append(res, FromStringPtr(each))
+	}
+	return res
+}

--- a/vendor/github.com/evergreen-ci/utility/random.go
+++ b/vendor/github.com/evergreen-ci/utility/random.go
@@ -1,0 +1,21 @@
+package utility
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// MakeRandomString constructs a hex-encoded random string of a
+// specific length. The size reflects the number of random bytes, not
+// the length of the string.
+func MakeRandomString(size int) string {
+	b := make([]byte, size)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+
+}
+
+// RandomString returns a hex-encoded cryptographically random string.
+// This function always returns 16bytes of randomness encoded in a 32
+// character string.
+func RandomString() string { return MakeRandomString(16) }

--- a/vendor/github.com/evergreen-ci/utility/random_test.go
+++ b/vendor/github.com/evergreen-ci/utility/random_test.go
@@ -1,0 +1,31 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandom(t *testing.T) {
+	t.Run("Legacy", func(t *testing.T) {
+		r1 := RandomString()
+		r2 := RandomString()
+		assert.NotEqual(t, r1, r2)
+		assert.Len(t, RandomString(), 32)
+	})
+	t.Run("Sized", func(t *testing.T) {
+		assert.Len(t, MakeRandomString(32), 64)
+		assert.Len(t, MakeRandomString(64), 128)
+		assert.Len(t, MakeRandomString(2), 4)
+		assert.Len(t, MakeRandomString(1), 2)
+		assert.Len(t, MakeRandomString(3), 6)
+
+		for i := 1; i < 100; i++ {
+			a := MakeRandomString(i)
+			b := MakeRandomString(i)
+			assert.Equal(t, len(a), len(b))
+			assert.NotEqual(t, a, b)
+			assert.Len(t, a, 2*i)
+		}
+	})
+}

--- a/vendor/github.com/evergreen-ci/utility/slice.go
+++ b/vendor/github.com/evergreen-ci/utility/slice.go
@@ -1,0 +1,121 @@
+package utility
+
+import (
+	"sort"
+	"strings"
+)
+
+// StringSliceContains determines if a string is in a slice
+func StringSliceContains(slice []string, item string) bool {
+	if len(slice) == 0 {
+		return false
+	}
+
+	for idx := range slice {
+		if slice[idx] == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+// StringSliceIntersection returns the intersecting elements of slices a and b.
+func StringSliceIntersection(a, b []string) []string {
+	inA := map[string]bool{}
+	out := []string{}
+	for _, elem := range a {
+		inA[elem] = true
+	}
+	for _, elem := range b {
+		if inA[elem] {
+			out = append(out, elem)
+		}
+	}
+	return out
+}
+
+// StringSliceSymmetricDifference returns only elements not in common between 2 slices
+// (ie. inverse of the intersection)
+func StringSliceSymmetricDifference(a, b []string) ([]string, []string) {
+	mapA := map[string]bool{}
+	mapAcopy := map[string]bool{}
+	for _, elem := range a {
+		mapA[elem] = true
+		mapAcopy[elem] = true
+	}
+	inB := []string{}
+	for _, elem := range b {
+		if mapAcopy[elem] { // need to delete from the copy in case B has duplicates of the same value in A
+			delete(mapA, elem)
+		} else {
+			inB = append(inB, elem)
+		}
+	}
+	inA := []string{}
+	for elem := range mapA {
+		inA = append(inA, elem)
+	}
+	return inA, inB
+}
+
+// UniqueStrings takes a slice of strings and returns a new slice with duplicates removed.
+// Order is preserved.
+func UniqueStrings(slice []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, s := range slice {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// SplitCommas returns the slice of strings after splitting each string by
+// commas.
+func SplitCommas(originals []string) []string {
+	splitted := []string{}
+	for _, original := range originals {
+		splitted = append(splitted, strings.Split(original, ",")...)
+	}
+	return splitted
+}
+
+// GetSetDifference returns the elements in A that are not in B
+func GetSetDifference(a, b []string) []string {
+	setB := make(map[string]struct{})
+	setDifference := make(map[string]struct{})
+
+	for _, e := range b {
+		setB[e] = struct{}{}
+	}
+	for _, e := range a {
+		if _, ok := setB[e]; !ok {
+			setDifference[e] = struct{}{}
+		}
+	}
+
+	d := make([]string, 0, len(setDifference))
+	for k := range setDifference {
+		d = append(d, k)
+	}
+
+	return d
+}
+
+// IndexOf returns the first occurence of a string in a sorted array
+func IndexOf(a []string, toFind string) int {
+	i := sort.Search(len(a), func(index int) bool {
+		return strings.Compare(a[index], toFind) >= 0
+	})
+	if i < 0 || i >= len(a) {
+		return -1
+	}
+	if a[i] == toFind {
+		return i
+	}
+	return -1
+}

--- a/vendor/github.com/evergreen-ci/utility/slice_test.go
+++ b/vendor/github.com/evergreen-ci/utility/slice_test.go
@@ -1,0 +1,96 @@
+package utility
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringSliceIntersection(t *testing.T) {
+	a := []string{"A", "B", "C", "D"}
+	b := []string{"C", "D", "E"}
+
+	assert.Equal(t, 2, len(StringSliceIntersection(a, b)))
+	assert.Contains(t, StringSliceIntersection(a, b), "C")
+	assert.Contains(t, StringSliceIntersection(a, b), "D")
+}
+
+func TestUniqueStrings(t *testing.T) {
+	assert.EqualValues(t, []string{"a", "b", "c", "d", "e"},
+		UniqueStrings([]string{"a", "b", "c", "a", "a", "d", "d", "e"}))
+
+	assert.EqualValues(t, []string{"a", "b", "c"},
+		UniqueStrings([]string{"a", "b", "c"}))
+}
+
+func TestSplitCommas(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T){
+		"ReturnsUnmodifiedStringsWithoutCommas": func(t *testing.T) {
+			input := []string{"foo", "bar", "bat"}
+			assert.Equal(t, input, SplitCommas(input))
+		},
+		"ReturnsSplitCommaStrings": func(t *testing.T) {
+			input := []string{"foo,bar", "bat", "baz,qux,quux"}
+			expected := []string{"foo", "bar", "bat", "baz", "qux", "quux"}
+			assert.Equal(t, expected, SplitCommas(input))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t)
+		})
+	}
+}
+
+func TestStringSliceSymmetricDifference(t *testing.T) {
+	a := []string{"a", "c", "f", "n", "q"}
+	b := []string{"q", "q", "g", "y", "a"}
+
+	onlyA, onlyB := StringSliceSymmetricDifference(a, b)
+	assert.Contains(t, onlyA, "c")
+	assert.Contains(t, onlyA, "f")
+	assert.Contains(t, onlyA, "n")
+	assert.Len(t, onlyA, 3)
+	assert.Contains(t, onlyB, "g")
+	assert.Contains(t, onlyB, "y")
+	assert.Len(t, onlyB, 2)
+
+	onlyB, onlyA = StringSliceSymmetricDifference(b, a)
+	assert.Contains(t, onlyA, "c")
+	assert.Contains(t, onlyA, "f")
+	assert.Contains(t, onlyA, "n")
+	assert.Len(t, onlyA, 3)
+	assert.Contains(t, onlyB, "g")
+	assert.Contains(t, onlyB, "y")
+	assert.Len(t, onlyB, 2)
+
+	onlyA, onlyB = StringSliceSymmetricDifference(a, a)
+	assert.Equal(t, []string{}, onlyA)
+	assert.Equal(t, []string{}, onlyB)
+
+	empty1, empty2 := StringSliceSymmetricDifference([]string{}, []string{})
+	assert.Equal(t, []string{}, empty1)
+	assert.Equal(t, []string{}, empty2)
+}
+
+func TestGetSetDifference(t *testing.T) {
+	assert := assert.New(t)
+	setA := []string{"one", "four", "five", "three", "two"}
+	setB := []string{"five", "two"}
+	difference := GetSetDifference(setA, setB)
+	sort.Strings(difference)
+
+	// GetSetDifference returns the elements in A that are not in B
+	assert.Equal(3, len(difference))
+	assert.Equal("four", difference[0])
+	assert.Equal("one", difference[1])
+	assert.Equal("three", difference[2])
+}
+
+func TestIndexOf(t *testing.T) {
+	assert.Equal(t, 3, IndexOf([]string{"a", "b", "c", "d", "e"}, "d"))
+	assert.Equal(t, 0, IndexOf([]string{"a", "b", "c", "d", "e"}, "a"))
+	assert.Equal(t, -1, IndexOf([]string{"a", "b", "c", "d", "e"}, "f"))
+	assert.Equal(t, -1, IndexOf([]string{"a", "b", "c", "d", "e"}, "1"))
+	assert.Equal(t, -1, IndexOf([]string{"a", "b", "c", "d", "e"}, "æ"))
+}

--- a/vendor/github.com/evergreen-ci/utility/time.go
+++ b/vendor/github.com/evergreen-ci/utility/time.go
@@ -1,0 +1,142 @@
+package utility
+
+import (
+	"math/rand"
+	"time"
+)
+
+// ZeroTime represents 0 in epoch time
+var ZeroTime time.Time = time.Unix(0, 0)
+
+// MaxTime represents the latest useful golang date (219248499-12-06 15:30:07.999999999 +0000 UTC)
+var MaxTime time.Time = time.Unix(1<<63-62135596801, 999999999)
+
+// IsZeroTime checks that a time is either equal to golang ZeroTime or
+// UTC ZeroTime.
+func IsZeroTime(t time.Time) bool {
+	return t.Equal(ZeroTime) || t.IsZero()
+}
+
+// UnixMilli returns t as a Unix time, the number of nanoseconds elapsed since
+// January 1, 1970 UTC. The result is undefined if the Unix time in nanoseconds
+// in cannot be represented by an int64 (a date before the year 1678 or after
+// 2262). Note that this means the result of calling UnixMilli on the zero Time
+// on the zero Time is undefined. The result does not depend on the location
+// associated with t.
+func UnixMilli(t time.Time) int64 {
+	return t.UnixNano() / 1e6
+}
+
+// fromNanoSeconds returns milliseconds of a duration for queries in the database.
+func FromNanoseconds(duration time.Duration) int64 {
+	return int64(duration) / 1000000
+}
+
+// fromNanoSeconds returns milliseconds of a duration for queries in the database.
+func ToNanoseconds(duration time.Duration) time.Duration {
+	return duration * 1000000
+}
+
+// FromPythonTime returns a time.Time that corresponds to the float style
+// python time which is <seconds>.<fractional_seconds> from unix epoch.
+func FromPythonTime(pyTime float64) time.Time {
+	sec := int64(pyTime)
+	toNano := int64(1000000000)
+	asNano := int64(pyTime * float64(toNano))
+	nano := asNano % toNano
+	res := time.Unix(sec, nano)
+	return res
+}
+
+// ToPythonTime returns a number in the format that python's time.time() returns
+// as a float with <seconds>.<fractional_seconds>
+func ToPythonTime(t time.Time) float64 {
+	if IsZeroTime(t) {
+		return float64(0)
+	}
+	timeAsInt64 := t.UnixNano()
+	fromNano := float64(1000000000)
+
+	res := float64(timeAsInt64) / fromNano
+	return res
+}
+
+// JitterInterval returns a duration that some value between the
+// interval and 2x the interval.
+func JitterInterval(interval time.Duration) time.Duration {
+	return time.Duration(rand.Float64()*float64(interval)) + interval
+}
+
+// RoundPartOfDay produces a time value with the hour value
+// rounded down to the most recent interval.
+func RoundPartOfDay(n int) time.Time { return findPartHour(time.Now(), n) }
+
+// RoundPartOfHour produces a time value with the minute value
+// rounded down to the most recent interval.
+func RoundPartOfHour(n int) time.Time { return findPartMin(time.Now(), n) }
+
+// RoundPartOfMinute produces a time value with the second value
+// rounded down to the most recent interval.
+func RoundPartOfMinute(n int) time.Time { return findPartSec(time.Now(), n) }
+
+// this implements the logic of RoundPartOfDay, but takes time as an
+// argument for testability.
+func findPartHour(now time.Time, num int) time.Time {
+	var hour int
+
+	if num > now.Hour() || num > 12 || num <= 0 {
+		hour = 0
+	} else {
+		hour = now.Hour() - (now.Hour() % num)
+	}
+
+	return time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, time.UTC)
+}
+
+// this implements the logic of RoundPartOfHour, but takes time as an
+// argument for testability.
+func findPartMin(now time.Time, num int) time.Time {
+	var min int
+
+	if num > now.Minute() || num > 30 || num <= 0 {
+		min = 0
+	} else {
+		min = now.Minute() - (now.Minute() % num)
+	}
+
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), min, 0, 0, time.UTC)
+}
+
+// this implements the logic of RoundPartOfMinute, but takes time as an
+// argument for testability.
+func findPartSec(now time.Time, num int) time.Time {
+	var sec int
+
+	if num > now.Second() || num > 30 || num <= 0 {
+		sec = 0
+	} else {
+		sec = now.Second() - (now.Second() % num)
+	}
+
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), sec, 0, time.UTC)
+
+}
+
+// Creates and returns a time.Time corresponding to the start of the UTC day containing the given date.
+func GetUTCDay(date time.Time) time.Time {
+	// Convert to UTC.
+	date = date.In(time.UTC)
+	// Create a new time.Time for the beginning of the day.
+	year, month, day := date.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+// Creates and returns a time.Time corresponding to the start of the UTC hour containing the given date.
+func GetUTCHour(date time.Time) time.Time {
+	// Convert to UTC.
+	date = date.In(time.UTC)
+	// Create a new time.Time for the beginning of the hour.
+	year, month, day := date.Date()
+	hour := date.Hour()
+	return time.Date(year, month, day, hour, 0, 0, 0, time.UTC)
+}

--- a/vendor/github.com/evergreen-ci/utility/time_test.go
+++ b/vendor/github.com/evergreen-ci/utility/time_test.go
@@ -1,0 +1,179 @@
+package utility
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeJitter(t *testing.T) {
+	assert := assert.New(t)
+
+	for i := 0; i < 100; i++ {
+		t := JitterInterval(time.Second * 15)
+		assert.True(t >= 15*time.Second)
+		assert.True(t <= 30*time.Second)
+	}
+}
+
+func TestTimeRoundPartHour(t *testing.T) {
+	assert := assert.New(t)
+
+	// make sure the fixtures work:
+	for i := 0; i < 24; i++ {
+		assert.Equal(i, getTimeWithHour(i).Hour())
+	}
+
+	type timeParts struct {
+		expectedValue int
+		actualHours   int
+		interval      int
+	}
+
+	cases := []timeParts{
+		{0, 3, 6},
+		{0, 5, 6},
+		{0, 6, 10},
+		{0, 15, 13},
+		{2, 3, 2},
+		{4, 4, 2},
+		{4, 5, 2},
+		{5, 8, 5},
+		{5, 9, 5},
+		{6, 6, 6},
+		{6, 8, 6},
+		{10, 10, 5},
+		{10, 12, 10},
+		{10, 15, 10},
+		{10, 18, 10},
+		{12, 14, 6},
+		{15, 16, 5},
+		{18, 23, 6},
+		{0, 0, -1},
+	}
+
+	for _, c := range cases {
+		assert.Equal(c.expectedValue, findPartHour(getTimeWithHour(c.actualHours), c.interval).Hour(),
+			fmt.Sprintf("%+v", c))
+	}
+
+	assert.NotPanics(func() {
+		findPartHour(getTimeWithHour(0), 0)
+	})
+
+}
+
+func TestTimeRoundPartMinute(t *testing.T) {
+	assert := assert.New(t)
+
+	// make sure the fixtures work:
+	for i := 0; i < 60; i++ {
+		assert.Equal(i, getTimeWithMin(i).Minute())
+	}
+
+	type timeParts struct {
+		expectedValue int
+		actualMins    int
+		interval      int
+	}
+
+	cases := []timeParts{
+		{0, 12, 30},
+		{0, 13, 40},
+		{0, 48, 40},
+		{0, 27, 31},
+		{2, 3, 2},
+		{4, 4, 2},
+		{4, 5, 2},
+		{5, 8, 5},
+		{5, 9, 5},
+		{10, 10, 5},
+		{10, 12, 10},
+		{10, 15, 10},
+		{10, 18, 10},
+		{15, 16, 5},
+		{20, 20, 20},
+		{20, 27, 20},
+		{20, 28, 10},
+		{24, 25, 2},
+		{30, 48, 30},
+		{0, 0, -1},
+	}
+
+	for _, c := range cases {
+		assert.Equal(c.expectedValue, findPartMin(getTimeWithMin(c.actualMins), c.interval).Minute(),
+			fmt.Sprintf("%+v", c))
+	}
+
+	assert.NotPanics(func() {
+		findPartMin(getTimeWithMin(0), 0)
+	})
+
+}
+
+func TestTimeRoundPartSecond(t *testing.T) {
+	assert := assert.New(t)
+
+	// make sure the fixtures work:
+	for i := 0; i < 60; i++ {
+		assert.Equal(i, getTimeWithSec(i).Second())
+	}
+
+	type timeParts struct {
+		expectedValue int
+		actualSecs    int
+		interval      int
+	}
+
+	cases := []timeParts{
+		{0, 12, 30},
+		{0, 13, 40},
+		{0, 48, 40},
+		{0, 27, 31},
+		{2, 3, 2},
+		{4, 4, 2},
+		{4, 5, 2},
+		{5, 8, 5},
+		{5, 9, 5},
+		{10, 10, 5},
+		{10, 12, 10},
+		{10, 15, 10},
+		{10, 18, 10},
+		{15, 16, 5},
+		{20, 20, 20},
+		{20, 27, 20},
+		{20, 28, 10},
+		{24, 25, 2},
+		{30, 48, 30},
+		{0, 0, -1},
+	}
+
+	for _, c := range cases {
+		assert.Equal(c.expectedValue, findPartSec(getTimeWithSec(c.actualSecs), c.interval).Second(),
+			fmt.Sprintf("%+v", c))
+	}
+
+	assert.NotPanics(func() {
+		findPartSec(getTimeWithSec(0), 0)
+	})
+}
+
+func getTimeWithHour(hour int) time.Time {
+	now := time.Now()
+
+	return time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, time.UTC)
+}
+
+func getTimeWithMin(min int) time.Time {
+	now := time.Now()
+
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), min, 0, 0, time.UTC)
+}
+
+func getTimeWithSec(sec int) time.Time {
+	now := time.Now()
+
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), sec, 0, time.UTC)
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13545

* Add `NeedsRetry` option indicating whether the job should retry after it's been marked complete.
* Separate retry input options from retry output info to deal with optional input configuration. Instead of having a separate `SetRetryable` method, you can just call `UpdateRetryInfo` with `Retryable = true`.