### PR TITLE
EVG-13539: create job method to add error and mark for retry

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -68,6 +68,9 @@ type Job interface {
 	// AddError allows another actor to annotate the job with an
 	// error.
 	AddError(error)
+	// AddRetryableError annotates the job with an error and marks the job as
+	// needing to retry.
+	AddRetryableError(error)
 	// Error returns an error object if the task was an
 	// error. Typically if the job has not run, this is nil.
 	Error() error

--- a/job/base.go
+++ b/job/base.go
@@ -7,9 +7,8 @@ The Base type provides an implementation of the amboy.Job interface
 that does *not* have a Run method, and can be embedded in your own job
 implementations to avoid implemented duplicated common
 functionality. The type also implements several methods which are not
-part of the Job interface for error handling (e.g. AddError and
-HasErrors), and methods for marking tasks complete and setting the ID
-(e.g. MarkComplete and SetID).
+part of the Job interface for error handling (e.g. HasErrors), and methods for
+marking tasks complete and setting the ID (e.g. MarkComplete and SetID).
 
 All job implementations should use this functionality, although there
 are some situations where jobs may want independent implementation of
@@ -62,9 +61,8 @@ func (b *Base) MarkComplete() {
 	b.status.Completed = true
 }
 
-// AddError takes an error object and if it is non-nil, tracks it
-// internally. This operation is thread safe, but not part of the Job
-// interface.
+// AddError takes an error object and if it is non-nil, tracks it internally.
+// This operation is thread safe.
 func (b *Base) AddError(err error) {
 	if err != nil {
 		b.mutex.Lock()
@@ -72,6 +70,20 @@ func (b *Base) AddError(err error) {
 
 		b.status.Errors = append(b.status.Errors, err.Error())
 	}
+}
+
+// AddRetryableError takes an error object and if it is non-nil, tracks it
+// internally and marks the job as needing to retry. This operation is thread
+// safe.
+func (b *Base) AddRetryableError(err error) {
+	if err == nil {
+		return
+	}
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.status.Errors = append(b.status.Errors, err.Error())
+	b.retryInfo.NeedsRetry = true
 }
 
 // HasErrors checks the stored errors in the object and reports if

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -45,6 +45,16 @@ func (s *BaseCheckSuite) TestAddErrorWithNilObjectDoesNotChangeErrorState() {
 	}
 }
 
+func (s *BaseCheckSuite) TestAddRetryableErrorWithNilObjectDoesNotChangeErrorState() {
+	for i := 0; i < 100; i++ {
+		s.base.AddRetryableError(nil)
+		s.NoError(s.base.Error())
+		s.Len(s.base.status.Errors, 0)
+		s.False(s.base.HasErrors())
+		s.False(s.base.RetryInfo().NeedsRetry)
+	}
+}
+
 func (s *BaseCheckSuite) TestAddErrorsPersistsErrorsInJob() {
 	for i := 1; i <= 100; i++ {
 		s.base.AddError(errors.New("foo"))
@@ -52,6 +62,17 @@ func (s *BaseCheckSuite) TestAddErrorsPersistsErrorsInJob() {
 		s.Len(s.base.status.Errors, i)
 		s.True(s.base.HasErrors())
 		s.Len(strings.Split(s.base.Error().Error(), "\n"), i)
+	}
+}
+
+func (s *BaseCheckSuite) TestAddRetryableErrorsPersistsErrorsInJob() {
+	for i := 1; i <= 100; i++ {
+		s.base.AddRetryableError(errors.New("foo"))
+		s.Error(s.base.Error())
+		s.Len(s.base.status.Errors, i)
+		s.True(s.base.HasErrors())
+		s.Len(strings.Split(s.base.Error().Error(), "\n"), i)
+		s.True(s.base.RetryInfo().NeedsRetry)
 	}
 }
 

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -104,6 +104,14 @@ func (j *JobTest) AddError(err error) {
 	}
 }
 
+func (j *JobTest) AddRetryableError(err error) {
+	if err == nil {
+		return
+	}
+	j.HadError = true
+	j.Retry.NeedsRetry = true
+}
+
 func (j *JobTest) Type() amboy.JobType {
 	return j.T
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13539

* Add new `AddRetryableError` method to add an error and mark the job as needing to retry.
* Fix some incorrect/outdated documentation.