### PR TITLE
EVG-13835: safely add goroutines to WaitGroup in local runner

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -58,7 +58,7 @@ func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
 	}
 }
 
-func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup) {
+func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup, mu sync.Locker) {
 	var (
 		err    error
 		job    amboy.Job
@@ -75,7 +75,10 @@ func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup) 
 	//     return
 	// }
 
+	mu.Lock()
 	wg.Add(1)
+	mu.Unlock()
+
 	defer wg.Done()
 	defer func() {
 		// if we hit a panic we want to add an error to the job;
@@ -98,7 +101,7 @@ func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup) 
 				q.Complete(bctx, job)
 			}
 			// start a replacement worker.
-			go worker(bctx, id, q, wg)
+			go worker(bctx, id, q, wg, mu)
 		}
 
 		if cancel != nil {

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -66,10 +66,31 @@ func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup) 
 		ctx    context.Context
 	)
 
+	// kim: NOTE: if `go worker()` happens and the thread is added to the
+	// WaitGroup while Wait() is trying to handle a 0 count (e.g. the thread
+	// count hits 0, then goes back up to 1). We can fix this potentially by
+	// checking for context error either at the beginning of worker() _or_
+	// before every call to `go worker()`.
+	// if bctx.Err() != nil {
+	//     return
+	// }
+
 	wg.Add(1)
 	defer wg.Done()
 	defer func() {
 		// if we hit a panic we want to add an error to the job;
+		// kim: NOTE: let's say that executeJob panics due to the context
+		// cancellation (for whatever reason) during (*localWorkers).Close().
+		// Then, it will attempt to recover() by starting a new worker
+		// goroutine, which, while concurrently marking threads done, may
+		// temporarily hit count 0 but then the restarted worker will add 1 to
+		// the count and panic wg.Wait().
+		// For example, let's say there are 2 workers left (count=2). Worker 1 panics,
+		// hits this recovery handler, then starts a new goroutine (count=1).
+		// Then, worker 2 exits normally (count=0), which triggers wg.Wait() to
+		// check for doneness. However, the new goroutine adds one more thread
+		// (count=1) while it's still counting, causing the wg.Wait() to panic.
+		// Source: https://stackoverflow.com/questions/39800700/waitgroup-is-reused-before-previous-wait-has-returned
 		err = recovery.HandlePanicWithError(recover(), nil, "worker process encountered error")
 		if err != nil {
 			if job != nil {

--- a/pool/local.go
+++ b/pool/local.go
@@ -85,7 +85,7 @@ func (r *localWorkers) Start(ctx context.Context) error {
 	r.canceler = cancel
 
 	for w := 1; w <= r.size; w++ {
-		go worker(workerCtx, "local", r.queue, &r.wg)
+		go worker(workerCtx, "local", r.queue, &r.wg, &r.mu)
 		grip.Debugf("started worker %d of %d waiting for jobs", w, r.size)
 	}
 

--- a/pool/local_test.go
+++ b/pool/local_test.go
@@ -52,7 +52,7 @@ func (s *LocalWorkersSuite) TestPanicJobsDoNotPanicHarness() {
 	wg := &sync.WaitGroup{}
 
 	s.queue.toProcess = jobsChanWithPanicingJobs(ctx, s.size)
-	s.NotPanics(func() { worker(ctx, "test-local", s.queue, wg) })
+	s.NotPanics(func() { worker(ctx, "test-local", s.queue, wg, &sync.Mutex{}) })
 }
 
 func (s *LocalWorkersSuite) TestConstructedInstanceImplementsInterface() {

--- a/pool/single.go
+++ b/pool/single.go
@@ -70,7 +70,7 @@ func (r *single) Start(ctx context.Context) error {
 	waiter := make(chan struct{})
 	go func(wg *sync.WaitGroup) {
 		close(waiter)
-		worker(workerCtx, "single", r.queue, wg)
+		worker(workerCtx, "single", r.queue, wg, &r.mu)
 		grip.Info("worker process complete")
 	}(&r.wg)
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13835

The local workers were not adding goroutines to the WaitGroup in a thread-safe way because they were adding themselves within a goroutine rather than the main thread. If `Close()` is called, once the WaitGroup count reaches 0, no goroutine is allowed to increment the count again until `(sync.WaitGroup).Wait()` finishes. Therefore, if a new goroutine starts (e.g. a goroutine panics and restarts itself), it will add itself to the WaitGroup and can cause a panic. I fixed this by locking `(sync.WaitGroup).Add()` which prevents concurrent access to the Runner's WaitGroup between the main thread and the goroutine workers.