### PR TITLE
EVG-13652: release dispatched jobs that error before they execute

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -100,7 +100,7 @@ func RunJob(ctx context.Context, job Job) error {
 	job.Run(ctx)
 	ti.End = time.Now()
 	msg := message.Fields{
-		"job":           job.ID(),
+		"job_id":        job.ID(),
 		"job_type":      job.Type().Name,
 		"duration_secs": ti.Duration().Seconds(),
 	}

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -39,7 +39,7 @@ func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
 	// dispatch succeeded but the job never executed Run(), then another app
 	// server took the job (evergreenapp-20 -> evergreenapp-3)
 	r := message.Fields{
-		"job":           job.ID(),
+		"job_id":        job.ID(),
 		"job_type":      job.Type().Name,
 		"duration_secs": ti.Duration().Seconds(),
 		"dispatch_secs": ti.Start.Sub(ti.Created).Seconds(),

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -35,9 +35,6 @@ func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
 	job.Run(jobCtx)
 	q.Complete(ctx, job)
 	ti := job.TimeInfo()
-	// kim: NOTE: TimeInfo.Start wasn't set unti 12-29, which means that
-	// dispatch succeeded but the job never executed Run(), then another app
-	// server took the job (evergreenapp-20 -> evergreenapp-3)
 	r := message.Fields{
 		"job_id":        job.ID(),
 		"job_type":      job.Type().Name,

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -35,6 +35,9 @@ func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
 	job.Run(jobCtx)
 	q.Complete(ctx, job)
 	ti := job.TimeInfo()
+	// kim: NOTE: TimeInfo.Start wasn't set unti 12-29, which means that
+	// dispatch succeeded but the job never executed Run(), then another app
+	// server took the job (evergreenapp-20 -> evergreenapp-3)
 	r := message.Fields{
 		"job":           job.ID(),
 		"job_type":      job.Type().Name,

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -59,7 +59,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 			"message":  "re-dispatching job that has already been dispatched",
 			"queue_id": d.queue.ID(),
 			"job_id":   job.ID(),
-			"service":  "amboy.dispatcher",
+			"service":  "amboy.queue.dispatcher",
 		})
 		delete(d.cache, job.ID())
 	}
@@ -104,7 +104,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 						"message":   "failed to lock job for lock ping",
 						"queue_id":  d.queue.ID(),
 						"job_id":    job.ID(),
-						"service":   "amboy.dispatcher",
+						"service":   "amboy.queue.dispatcher",
 						"ping_iter": iters,
 						"stat":      job.Status(),
 					}))
@@ -117,7 +117,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 						"message":   "failed to save job for lock ping",
 						"queue_id":  d.queue.ID(),
 						"job_id":    job.ID(),
-						"service":   "amboy.dispatcher",
+						"service":   "amboy.queue.dispatcher",
 						"ping_iter": iters,
 						"stat":      job.Status(),
 					}))
@@ -128,7 +128,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 				grip.Debug(message.Fields{
 					"queue_id":  d.queue.ID(),
 					"job_id":    job.ID(),
-					"service":   "amboy.dispatcher",
+					"service":   "amboy.queue.dispatcher",
 					"ping_iter": iters,
 					"stat":      job.Status(),
 				})

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -59,7 +59,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 			"message":  "re-dispatching job that has already been dispatched",
 			"queue_id": d.queue.ID(),
 			"job_id":   job.ID(),
-			"service":  "amboy.queue.dispatcher",
+			"service":  "amboy.dispatcher",
 		})
 		delete(d.cache, job.ID())
 	}
@@ -104,7 +104,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 						"message":   "failed to lock job for lock ping",
 						"queue_id":  d.queue.ID(),
 						"job_id":    job.ID(),
-						"service":   "amboy.queue.dispatcher",
+						"service":   "amboy.dispatcher",
 						"ping_iter": iters,
 						"stat":      job.Status(),
 					}))
@@ -117,7 +117,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 						"message":   "failed to save job for lock ping",
 						"queue_id":  d.queue.ID(),
 						"job_id":    job.ID(),
-						"service":   "amboy.queue.dispatcher",
+						"service":   "amboy.dispatcher",
 						"ping_iter": iters,
 						"stat":      job.Status(),
 					}))
@@ -128,7 +128,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 				grip.Debug(message.Fields{
 					"queue_id":  d.queue.ID(),
 					"job_id":    job.ID(),
-					"service":   "amboy.queue.dispatcher",
+					"service":   "amboy.dispatcher",
 					"ping_iter": iters,
 					"stat":      job.Status(),
 				})

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -711,9 +711,9 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 	var (
 		qd             bson.M
 		job            amboy.Job
-		misses         int64
-		dispatchMisses int64
-		dispatchSkips  int64
+		misses         int
+		dispatchMisses int
+		dispatchSkips  int
 	)
 
 	startAt := time.Now()
@@ -744,7 +744,6 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 
-RETRY:
 	for {
 		select {
 		case <-ctx.Done():
@@ -766,97 +765,16 @@ RETRY:
 				return nil
 			}
 
-		CURSOR:
-			for iter.Next(ctx) {
-				if err = iter.Decode(j); err != nil {
-					grip.Warning(message.WrapError(err, message.Fields{
-						"id":            d.instanceID,
-						"service":       "amboy.queue.mdb",
-						"operation":     "converting next job",
-						"message":       "problem reading document from cursor",
-						"is_group":      d.opts.UseGroups,
-						"group":         d.opts.GroupName,
-						"duration_secs": time.Since(startAt).Seconds(),
-					}))
-					// try for the next thing in the iterator if we can
-					continue CURSOR
-				}
-
-				job, err = j.Resolve(d.opts.Format)
-				if err != nil {
-					grip.Warning(message.WrapError(err, message.Fields{
-						"id":            d.instanceID,
-						"service":       "amboy.queue.mdb",
-						"operation":     "converting document",
-						"message":       "problem converting job from intermediate form",
-						"is_group":      d.opts.UseGroups,
-						"group":         d.opts.GroupName,
-						"duration_secs": time.Since(startAt).Seconds(),
-					}))
-					// try for the next thing in the iterator if we can
-					job = nil
-					continue CURSOR
-				}
-
-				if job.TimeInfo().IsStale() {
-					var res *mongo.DeleteResult
-
-					res, err = d.getCollection().DeleteOne(ctx, bson.M{"_id": job.ID()})
-					msg := message.Fields{
-						"id":            d.instanceID,
-						"service":       "amboy.queue.mdb",
-						"num_deleted":   res.DeletedCount,
-						"message":       "found stale job",
-						"operation":     "job staleness check",
-						"job":           job.ID(),
-						"job_type":      job.Type().Name,
-						"is_group":      d.opts.UseGroups,
-						"group":         d.opts.GroupName,
-						"duration_secs": time.Since(startAt).Seconds(),
-					}
-					grip.Warning(message.WrapError(err, msg))
-					grip.NoticeWhen(err == nil, msg)
-					job = nil
-					continue CURSOR
-				}
-
-				if !isDispatchable(job.Status(), d.opts.LockTimeout) {
-					dispatchSkips++
-					job = nil
-					continue CURSOR
-				} else if d.scopesInUse(ctx, job.Scopes()) && !jobCanRestart(job.Status(), d.opts.LockTimeout) {
-					dispatchSkips++
-					job = nil
-					continue CURSOR
-				}
-
-				if err = d.dispatcher.Dispatch(ctx, job); err != nil {
-					dispatchMisses++
-					grip.DebugWhen(
-						isDispatchable(job.Status(), d.opts.LockTimeout),
-						message.WrapError(err, message.Fields{
-							"id":            d.instanceID,
-							"service":       "amboy.queue.mdb",
-							"operation":     "dispatch job",
-							"job_id":        job.ID(),
-							"job_type":      job.Type().Name,
-							"scopes":        job.Scopes(),
-							"stat":          job.Status(),
-							"is_group":      d.opts.UseGroups,
-							"group":         d.opts.GroupName,
-							"dup_key":       isMongoDupKey(err),
-							"duration_secs": time.Since(startAt).Seconds(),
-						}),
-					)
-					job = nil
-					continue CURSOR
-				}
-				break CURSOR
-			}
-
+			var dispatchInfo dispatchAttemptInfo
+			job, dispatchInfo := d.tryDispatchJob(ctx, iter, startAt)
+			dispatchMisses += dispatchInfo.misses
+			dispatchSkips += dispatchInfo.skips
 			if err = iter.Err(); err != nil {
 				// kim: NOTE: this should cause the dispatcher to release the
 				// job if it's non-nil
+				if job != nil {
+					d.dispatcher.Release(ctx, job)
+				}
 				grip.Warning(message.WrapError(err, message.Fields{
 					"id":            d.instanceID,
 					"service":       "amboy.queue.mdb",
@@ -872,6 +790,9 @@ RETRY:
 			if err = iter.Close(ctx); err != nil {
 				// kim: NOTE: this should cause the dispatcher to release the
 				// job if it's non-nil
+				if job != nil {
+					d.dispatcher.Release(ctx, job)
+				}
 				grip.Warning(message.WrapError(err, message.Fields{
 					"id":        d.instanceID,
 					"service":   "amboy.queue.mdb",
@@ -884,14 +805,116 @@ RETRY:
 			}
 
 			if job != nil {
-				break RETRY
+				return job
 			}
 
-			timer.Reset(time.Duration(misses * rand.Int63n(int64(d.opts.WaitInterval))))
-			continue RETRY
+			timer.Reset(time.Duration(misses * rand.Intn(int(d.opts.WaitInterval))))
 		}
 	}
-	return job
+	return nil
+}
+
+// dispatchAttemptInfo contains aggregate statistics on an attempt to dispatch
+// jobs.
+type dispatchAttemptInfo struct {
+	// skips is the number of times it encountered a job that was not yet ready
+	// to dispatch.
+	skips int
+	// misses is the number of times the dispatcher attempted to dispatch a job
+	// but failed.
+	misses int
+}
+
+// tryDispatchJob takes an iterator over the candidate Amboy jobs and attempts
+// to dispatch one of them. If it succeeds, it returns the successfully
+// dispatched job.
+func (d *mongoDriver) tryDispatchJob(ctx context.Context, iter *mongo.Cursor, startAt time.Time) (amboy.Job, dispatchAttemptInfo) {
+	var dispatchInfo dispatchAttemptInfo
+	for iter.Next(ctx) {
+		j := &registry.JobInterchange{}
+		if err := iter.Decode(j); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"id":            d.instanceID,
+				"service":       "amboy.queue.mdb",
+				"operation":     "converting next job",
+				"message":       "problem reading document from cursor",
+				"is_group":      d.opts.UseGroups,
+				"group":         d.opts.GroupName,
+				"duration_secs": time.Since(startAt).Seconds(),
+			}))
+			// try for the next thing in the iterator if we can
+			continue
+		}
+
+		job, err := j.Resolve(d.opts.Format)
+		if err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"id":            d.instanceID,
+				"service":       "amboy.queue.mdb",
+				"operation":     "converting document",
+				"message":       "problem converting job from intermediate form",
+				"is_group":      d.opts.UseGroups,
+				"group":         d.opts.GroupName,
+				"duration_secs": time.Since(startAt).Seconds(),
+			}))
+			// try for the next thing in the iterator if we can
+			continue
+		}
+
+		if job.TimeInfo().IsStale() {
+			// Delete stale jobs from the queue.
+			var res *mongo.DeleteResult
+
+			res, err = d.getCollection().DeleteOne(ctx, bson.M{"_id": job.ID()})
+			msg := message.Fields{
+				"id":            d.instanceID,
+				"service":       "amboy.queue.mdb",
+				"num_deleted":   res.DeletedCount,
+				"message":       "found stale job",
+				"operation":     "job staleness check",
+				"job":           job.ID(),
+				"job_type":      job.Type().Name,
+				"is_group":      d.opts.UseGroups,
+				"group":         d.opts.GroupName,
+				"duration_secs": time.Since(startAt).Seconds(),
+			}
+			grip.Warning(message.WrapError(err, msg))
+			grip.NoticeWhen(err == nil, msg)
+			continue
+		}
+
+		if !isDispatchable(job.Status(), d.opts.LockTimeout) {
+			dispatchInfo.skips++
+			continue
+		} else if d.scopesInUse(ctx, job.Scopes()) && !jobCanRestart(job.Status(), d.opts.LockTimeout) {
+			dispatchInfo.skips++
+			continue
+		}
+
+		if err = d.dispatcher.Dispatch(ctx, job); err != nil {
+			dispatchInfo.misses++
+			grip.DebugWhen(
+				isDispatchable(job.Status(), d.opts.LockTimeout),
+				message.WrapError(err, message.Fields{
+					"id":            d.instanceID,
+					"service":       "amboy.queue.mdb",
+					"operation":     "dispatch job",
+					"job_id":        job.ID(),
+					"job_type":      job.Type().Name,
+					"scopes":        job.Scopes(),
+					"stat":          job.Status(),
+					"is_group":      d.opts.UseGroups,
+					"group":         d.opts.GroupName,
+					"dup_key":       isMongoDupKey(err),
+					"duration_secs": time.Since(startAt).Seconds(),
+				}),
+			)
+			continue
+		}
+		return job, dispatchInfo
+	}
+
+	return nil, dispatchInfo
 }
 
 func (d *mongoDriver) scopesInUse(ctx context.Context, scopes []string) bool {

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -163,7 +163,7 @@ func (d *mongoDriver) start(ctx context.Context, client *mongo.Client) error {
 func (d *mongoDriver) getCollection() *mongo.Collection {
 	db := d.client.Database(d.opts.DB)
 	if d.opts.UseGroups {
-		return db.Collection(addGroupSufix(d.name))
+		return db.Collection(addGroupSuffix(d.name))
 	}
 
 	return db.Collection(addJobsSuffix(d.name))

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -740,7 +740,6 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 		opts.SetSort(bson.M{"priority": -1})
 	}
 
-	j := &registry.JobInterchange{}
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 
@@ -765,13 +764,10 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 				return nil
 			}
 
-			var dispatchInfo dispatchAttemptInfo
 			job, dispatchInfo := d.tryDispatchJob(ctx, iter, startAt)
 			dispatchMisses += dispatchInfo.misses
 			dispatchSkips += dispatchInfo.skips
 			if err = iter.Err(); err != nil {
-				// kim: NOTE: this should cause the dispatcher to release the
-				// job if it's non-nil
 				if job != nil {
 					d.dispatcher.Release(ctx, job)
 				}
@@ -788,8 +784,6 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 			}
 
 			if err = iter.Close(ctx); err != nil {
-				// kim: NOTE: this should cause the dispatcher to release the
-				// job if it's non-nil
 				if job != nil {
 					d.dispatcher.Release(ctx, job)
 				}
@@ -811,7 +805,6 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 			timer.Reset(time.Duration(misses * rand.Intn(int(d.opts.WaitInterval))))
 		}
 	}
-	return nil
 }
 
 // dispatchAttemptInfo contains aggregate statistics on an attempt to dispatch

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -872,7 +872,7 @@ func (d *mongoDriver) tryDispatchJob(ctx context.Context, iter *mongo.Cursor, st
 				"num_deleted":   res.DeletedCount,
 				"message":       "found stale job",
 				"operation":     "job staleness check",
-				"job":           job.ID(),
+				"job_id":        job.ID(),
 				"job_type":      job.Type().Name,
 				"is_group":      d.opts.UseGroups,
 				"group":         d.opts.GroupName,

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -855,6 +855,8 @@ RETRY:
 			}
 
 			if err = iter.Err(); err != nil {
+				// kim: NOTE: this should cause the dispatcher to release the
+				// job if it's non-nil
 				grip.Warning(message.WrapError(err, message.Fields{
 					"id":            d.instanceID,
 					"service":       "amboy.queue.mdb",
@@ -868,6 +870,8 @@ RETRY:
 			}
 
 			if err = iter.Close(ctx); err != nil {
+				// kim: NOTE: this should cause the dispatcher to release the
+				// job if it's non-nil
 				grip.Warning(message.WrapError(err, message.Fields{
 					"id":        d.instanceID,
 					"service":   "amboy.queue.mdb",

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -152,7 +152,7 @@ func (q *limitedSizeLocal) Next(ctx context.Context) amboy.Job {
 
 				grip.Notice(message.Fields{
 					"state":    "stale",
-					"job":      job.ID(),
+					"job_id":   job.ID(),
 					"job_type": job.Type().Name,
 				})
 				misses++

--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -88,7 +88,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 }
 
 func (g *remoteMongoQueueGroupSingle) getQueues(ctx context.Context) ([]string, error) {
-	cursor, err := g.client.Database(g.dbOpts.DB).Collection(addGroupSufix(g.opts.Prefix)).Aggregate(ctx,
+	cursor, err := g.client.Database(g.dbOpts.DB).Collection(addGroupSuffix(g.opts.Prefix)).Aggregate(ctx,
 		[]bson.M{
 			{
 				"$match": bson.M{

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -182,10 +182,10 @@ func (q *depGraphOrderedLocal) Next(ctx context.Context) amboy.Job {
 	case job := <-q.channel:
 		grip.Error(message.WrapError(q.dispatcher.Dispatch(ctx, job),
 			message.Fields{
-				"job":    job.ID(),
-				"event":  "improperly dispatched job",
-				"impact": "possible duplicate execution",
-				"queue":  q.ID(),
+				"job_id":   job.ID(),
+				"event":    "improperly dispatched job",
+				"impact":   "possible duplicate execution",
+				"queue_id": q.ID(),
 			}))
 		return job
 	}

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -100,7 +100,7 @@ func (q *priorityLocalQueue) Next(ctx context.Context) amboy.Job {
 				q.storage.Remove(job.ID())
 				grip.Notice(message.Fields{
 					"state":    "stale",
-					"job":      job.ID(),
+					"job_id":   job.ID(),
 					"job_type": job.Type().Name,
 				})
 				continue

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -229,7 +229,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 						d.Close()
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addGroupSufix(name)).Drop(ctx)
+					return client.Database(opts.MDB.DB).Collection(addGroupSuffix(name)).Drop(ctx)
 				}
 
 				return q, closer, nil

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -103,6 +103,7 @@ func (q *remoteBase) jobServer(ctx context.Context) {
 						"message":   "releasing a job that's already been dispatched",
 						"service":   "amboy.queue.mdb",
 						"operation": "post-dispatch",
+						"job_id":    job.ID(),
 						"queue_id":  q.ID(),
 					})
 				}

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -104,8 +104,6 @@ func (q *remoteBase) jobServer(ctx context.Context) {
 				// in-memory queue ensures that only one worker gets to proceed
 				// through to actually run the job.
 
-				// kim: NOTE: this should cause the dispatcher to release the
-				// job because it's already been dispatched.
 				if job != nil {
 					q.dispatcher.Release(ctx, job)
 					grip.Warning(message.Fields{

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -95,21 +95,12 @@ func (q *remoteBase) jobServer(ctx context.Context) {
 		default:
 			job := q.driver.Next(ctx)
 			if !q.lockDispatch(job) {
-				// The dispatcer already ensures that the job is locked to a
-				// single in-memory queue on one host. However, the dispatcher
-				// cannot guarantee that a single worker on the host owns the
-				// job, it's still possible for two workers on the same host to
-				// dispatch the same job from a queue simultaneously via Next().
-				// Checking the dispatchability status of the job in this
-				// in-memory queue ensures that only one worker gets to proceed
-				// through to actually run the job.
-
 				if job != nil {
 					q.dispatcher.Release(ctx, job)
 					grip.Warning(message.Fields{
 						"message":   "releasing a job that's already been dispatched",
 						"service":   "amboy.queue.mdb",
-						"operation": "post-dispatch",
+						"operation": "post-dispatch lock",
 						"job_id":    job.ID(),
 						"queue_id":  q.ID(),
 					})

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -95,6 +95,7 @@ func (q *remoteBase) jobServer(ctx context.Context) {
 		default:
 			job := q.driver.Next(ctx)
 			if !q.canDispatch(job) {
+				// kim: TODO: need to release if dispatch is not possible.
 				continue
 			}
 

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -79,9 +79,9 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 			case dependency.Unresolved:
 				grip.Warning(message.MakeFieldsMessage("detected a dependency error",
 					message.Fields{
-						"job":   id,
-						"edges": dep.Edges(),
-						"dep":   dep.Type(),
+						"job_id": id,
+						"edges":  dep.Edges(),
+						"dep":    dep.Type(),
 					}))
 				q.dispatcher.Release(ctx, job)
 				q.addBlocked(job.ID())
@@ -89,7 +89,7 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 			case dependency.Blocked:
 				edges := dep.Edges()
 				grip.Debug(message.Fields{
-					"job":       id,
+					"job_id":    id,
 					"edges":     edges,
 					"dep":       dep.Type(),
 					"job_type":  job.Type().Name,
@@ -119,9 +119,9 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 				q.dispatcher.Release(ctx, job)
 				grip.Warning(message.MakeFieldsMessage("detected invalid dependency",
 					message.Fields{
-						"job":   id,
-						"edges": dep.Edges(),
-						"dep":   dep.Type(),
+						"job_id": id,
+						"edges":  dep.Edges(),
+						"dep":    dep.Type(),
 						"state": message.Fields{
 							"value":  dep.State(),
 							"valid":  dependency.IsValidState(dep.State()),

--- a/queue/util.go
+++ b/queue/util.go
@@ -21,6 +21,6 @@ func trimJobsSuffix(s string) string {
 	return strings.TrimSuffix(s, ".jobs")
 }
 
-func addGroupSufix(s string) string {
+func addGroupSuffix(s string) string {
 	return s + ".group"
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13652

A job got dispatched and the lock ping thread started, but the job never ran. The only places I could see where a job could be dispatched without running were a few exceptional error cases in between the dispatcher starting the lock ping thread and the `job.Run()` call. I made it so that all the exit conditions in between those two events cause the dispatcher to release the job. Since I didn't see any of the exceptional error logs in Splunk, I'm not confident that one of these errors was the cause, but the logging should be better now so we can diagnose it better if it recurs.

* Release any job that successfully gets dispatched but errors before it can run the job.  
* Refactor the dispatch attempt loop to be more readable.
* Add more logging at all the error cases after dispatch occurs but before the job gets run.