### PR TITLE
EVG-14017: use MongoDB 4.0 in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -196,21 +196,21 @@ buildvariants:
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
       RACE_DETECTOR: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m
     run_on:
-      - archlinux-build
+      - archlinux-large
     tasks:
       - ".test"
 
   - name: report
     display_name: Reporting
     run_on:
-      - archlinux-build
+      - archlinux-large
     expansions:
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
-      mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
+      mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
       test_timeout: 15m
     tasks:
       - name: ".report"
@@ -219,12 +219,12 @@ buildvariants:
   - name: ubuntu1604
     display_name: Ubuntu 16.04
     run_on:
-      - ubuntu1604-build
+      - ubuntu1604-large
     expansions:
       DISABLE_COVERAGE: true
       GO_BIN_PATH: /opt/golang/go1.9/bin/go
       GOROOT: /opt/golang/go1.9
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.4.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
     tasks:
       - name: ".dist"
       - name: ".test"
@@ -235,7 +235,7 @@ buildvariants:
       DISABLE_COVERAGE: true
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.4.tgz
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
       test_timeout: 15m
     run_on:
       - macos-1014
@@ -246,20 +246,16 @@ buildvariants:
   - name: windows
     display_name: Windows
     run_on:
-      - windows-64-vs2017-compile
-      - windows-64-vs2017-test
-      - windows-64-vs2015-compile
+      - windows-64-vs2017-large
+      - windows-64-vs2017-small
       - windows-64-vs2015-large
       - windows-64-vs2015-small
-      - windows-64-vs2015-test
-      - windows-64-vs2013-compile
-      - windows-64-vs2013-test
     expansions:
       GO_BIN_PATH: /cygdrive/c/golang/go1.13/bin/go
       GOROOT: C:/golang/go1.13
       DISABLE_COVERAGE: true
       test_timeout: 15m
-      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.6.4.zip
+      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
       extension: ".exe"
       archiveExt: ".zip"
     tasks:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14017