### PR TITLE
EVG-13540: reorganize to propagate retry handler options

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -277,6 +277,9 @@ type Queue interface {
 	// Begins the execution of the job Queue, using the embedded
 	// Runner.
 	Start(context.Context) error
+
+	// Close cleans up all resources used by the queue.
+	Close(context.Context)
 }
 
 // RetryableQueue is the same as a Queue but supports additional operations for

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -185,6 +185,8 @@ func (q *QueueTester) JobStats(ctx context.Context) <-chan amboy.JobStatusInfo {
 	return output
 }
 
+func (q *QueueTester) Close(context.Context) {}
+
 type jobThatPanics struct {
 	job.Base
 }

--- a/queue/adaptive_order.go
+++ b/queue/adaptive_order.go
@@ -351,3 +351,9 @@ func (q *adaptiveLocalOrdering) SetRunner(r amboy.Runner) error {
 	q.runner = r
 	return r.SetQueue(q)
 }
+
+func (q *adaptiveLocalOrdering) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}

--- a/queue/fixed.go
+++ b/queue/fixed.go
@@ -337,3 +337,9 @@ func (q *limitedSizeLocal) Start(ctx context.Context) error {
 
 	return nil
 }
+
+func (q *limitedSizeLocal) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}

--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -367,7 +367,7 @@ func (g *remoteMongoQueueGroup) Prune(ctx context.Context) error {
 					return
 				}
 				if queue, ok := g.queues[g.idFromCollection(nextColl)]; ok {
-					queue.Runner().Close(ctx)
+					queue.Close(ctx)
 					select {
 					case <-ctx.Done():
 						return
@@ -402,7 +402,7 @@ outer:
 		go func(queueID string, ch chan string, qu amboy.Queue) {
 			defer recovery.LogStackTraceAndContinue("panic in pruning queues")
 			defer wg.Done()
-			qu.Runner().Close(ctx)
+			qu.Close(ctx)
 			select {
 			case <-ctx.Done():
 				return
@@ -434,7 +434,7 @@ func (g *remoteMongoQueueGroup) Close(ctx context.Context) error {
 			go func(queue amboy.Queue) {
 				defer recovery.LogStackTraceAndContinue("panic in remote queue group closer")
 				defer wg.Done()
-				queue.Runner().Close(ctx)
+				queue.Close(ctx)
 			}(queue)
 		}
 		wg.Wait()

--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -62,7 +62,7 @@ type MongoDBQueueGroupOptions struct {
 	TTL time.Duration
 }
 
-func (opts *MongoDBQueueGroupOptions) constructor(ctx context.Context, name string, rhOpts amboy.RetryHandlerOptions) (remoteQueue, error) {
+func (opts *MongoDBQueueGroupOptions) constructor(ctx context.Context, name string) (remoteQueue, error) {
 	workers := opts.DefaultWorkers
 	if opts.WorkerPoolSize != nil {
 		workers = opts.WorkerPoolSize(name)
@@ -89,7 +89,7 @@ func (opts *MongoDBQueueGroupOptions) constructor(ctx context.Context, name stri
 			return nil, errors.Wrap(err, "configuring queue with runner")
 		}
 	}
-	rh, err := newBasicRetryHandler(q, rhOpts)
+	rh, err := newBasicRetryHandler(q, opts.RetryHandler)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing retry handler")
 	}
@@ -247,7 +247,7 @@ func (g *remoteMongoQueueGroup) Queues(ctx context.Context) []string {
 
 func (g *remoteMongoQueueGroup) startProcessingRemoteQueue(ctx context.Context, coll string) (amboy.Queue, error) {
 	coll = trimJobsSuffix(coll)
-	q, err := g.opts.constructor(ctx, coll, g.opts.RetryHandler)
+	q, err := g.opts.constructor(ctx, coll)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing queue")
 	}

--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -159,7 +159,7 @@ func (g *remoteMongoQueueGroupSingle) Get(ctx context.Context, id string) (amboy
 	case remoteQueue:
 		return q, nil
 	case nil:
-		queue, err = g.opts.constructor(ctx, id, g.opts.RetryHandler)
+		queue, err = g.opts.constructor(ctx, id)
 		if err != nil {
 			return nil, errors.Wrap(err, "constructing queue")
 		}

--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -153,12 +153,16 @@ func (g *remoteMongoQueueGroupSingle) startQueues(ctx context.Context) error {
 
 func (g *remoteMongoQueueGroupSingle) Get(ctx context.Context, id string) (amboy.Queue, error) {
 	var queue remoteQueue
+	var err error
 
 	switch q := g.cache.Get(id).(type) {
 	case remoteQueue:
 		return q, nil
 	case nil:
-		queue = g.opts.constructor(ctx, id)
+		queue, err = g.opts.constructor(ctx, id, g.opts.RetryHandler)
+		if err != nil {
+			return nil, errors.Wrap(err, "constructing queue")
+		}
 	default:
 		return q, nil
 	}

--- a/queue/group_util.go
+++ b/queue/group_util.go
@@ -134,7 +134,7 @@ func (c *cacheImpl) Remove(ctx context.Context, name string) error {
 		return errors.Errorf("cannot delete in progress queue, '%s'", name)
 	}
 
-	queue.Runner().Close(ctx)
+	queue.Close(ctx)
 	delete(c.q, name)
 	return nil
 }
@@ -186,7 +186,7 @@ func (c *cacheImpl) Prune(ctx context.Context) error {
 							defer recovery.LogStackTraceAndContinue("panic in queue waiting")
 							defer close(wait)
 
-							item.q.Runner().Close(ctx)
+							item.q.Close(ctx)
 							c.mu.Lock()
 							defer c.mu.Unlock()
 							catcher.Add(c.hook(ctx, item.name))
@@ -235,7 +235,7 @@ func (c *cacheImpl) Close(ctx context.Context) error {
 					go func() {
 						defer recovery.LogStackTraceAndContinue("panic in queue waiting")
 						defer close(wait)
-						item.q.Runner().Close(ctx)
+						item.q.Close(ctx)
 					}()
 					select {
 					case <-ctx.Done():

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -431,3 +431,9 @@ func (q *depGraphOrderedLocal) Complete(ctx context.Context, j amboy.Job) {
 	defer q.mutex.Unlock()
 	q.tasks.completed[j.ID()] = true
 }
+
+func (q *depGraphOrderedLocal) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}

--- a/queue/priority.go
+++ b/queue/priority.go
@@ -271,3 +271,9 @@ func (q *priorityLocalQueue) Start(ctx context.Context) error {
 
 	return nil
 }
+
+func (q *priorityLocalQueue) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -345,6 +345,15 @@ func (q *remoteBase) Start(ctx context.Context) error {
 	return nil
 }
 
+func (q *remoteBase) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+	if rh := q.RetryHandler(); rh != nil {
+		rh.Close(ctx)
+	}
+}
+
 // Next is a no-op that is included here so that it fulfills the amboy.Queue
 // interface.
 func (q *remoteBase) Next(context.Context) amboy.Job {

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -33,7 +33,7 @@ func newSimpleRemoteOrdered(size int) remoteQueue {
 	q.dispatcher = NewDispatcher(q)
 	grip.Error(q.SetRunner(pool.NewLocalWorkers(size, q)))
 	// TODO (EVG-13540): need a way to propagate RetryHandlerOptions
-	rh, err := newRetryHandler(q, amboy.RetryHandlerOptions{})
+	rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{})
 	grip.Error(errors.Wrap(err, "could not initialize retry handler"))
 	if rh != nil {
 		grip.Error(q.SetRetryHandler(rh))

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -28,19 +28,15 @@ type remoteSimpleOrdered struct {
 
 // newSimpleRemoteOrdered returns a queue with a configured local
 // runner with the specified number of workers.
-func newSimpleRemoteOrdered(size int) remoteQueue {
+func newSimpleRemoteOrdered(size int) (remoteQueue, error) {
 	q := &remoteSimpleOrdered{remoteBase: newRemoteBase()}
 	q.dispatcher = NewDispatcher(q)
-	grip.Error(q.SetRunner(pool.NewLocalWorkers(size, q)))
-	// TODO (EVG-13540): need a way to propagate RetryHandlerOptions
-	rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{})
-	grip.Error(errors.Wrap(err, "could not initialize retry handler"))
-	if rh != nil {
-		grip.Error(q.SetRetryHandler(rh))
+	if err := q.SetRunner(pool.NewLocalWorkers(size, q)); err != nil {
+		return nil, errors.Wrap(err, "configuring runner")
 	}
 	grip.Infof("creating new remote job queue with %d workers", size)
 
-	return q
+	return q, nil
 }
 
 // Next contains the unique implementation details of the

--- a/queue/remote_ordered_test.go
+++ b/queue/remote_ordered_test.go
@@ -69,8 +69,9 @@ func (s *SimpleRemoteOrderedSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.canceler = canceler
 	s.NoError(s.driver.Open(ctx))
-	queue := newSimpleRemoteOrdered(2)
-	s.NoError(queue.SetDriver(s.driver))
+	queue, err := newSimpleRemoteOrdered(2)
+	s.Require().NoError(err)
+	s.Require().NoError(queue.SetDriver(s.driver))
 	s.queue = queue
 }
 

--- a/queue/remote_test.go
+++ b/queue/remote_test.go
@@ -66,7 +66,11 @@ func (s *RemoteUnorderedSuite) SetupTest() {
 	s.driver, err = s.driverConstructor()
 	s.Require().NoError(err)
 	s.Require().NoError(s.driver.Open(s.ctx))
-	s.queue = newRemoteUnordered(2).(*remoteUnordered)
+	rq, err := newRemoteUnordered(2)
+	s.Require().NoError(err)
+	q, ok := rq.(*remoteUnordered)
+	s.Require().True(ok)
+	s.queue = q
 }
 
 func (s *RemoteUnorderedSuite) TearDownTest() {

--- a/queue/remote_unordered.go
+++ b/queue/remote_unordered.go
@@ -18,22 +18,18 @@ type remoteUnordered struct {
 
 // newRemoteUnordered returns a queue that has been initialized with a
 // local worker pool Runner instance of the specified size.
-func newRemoteUnordered(size int) remoteQueue {
+func newRemoteUnordered(size int) (remoteQueue, error) {
 	q := &remoteUnordered{
 		remoteBase: newRemoteBase(),
 	}
 
 	q.dispatcher = NewDispatcher(q)
-	grip.Error(q.SetRunner(pool.NewLocalWorkers(size, q)))
-	// TODO (EVG-13540): need a way to propagate RetryHandlerOptions
-	rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{})
-	grip.Error(errors.Wrap(err, "could not initialize retry handler"))
-	if rh != nil {
-		grip.Error(q.SetRetryHandler(rh))
+	if err := q.SetRunner(pool.NewLocalWorkers(size, q)); err != nil {
+		return nil, errors.Wrap(err, "configuring runner")
 	}
 	grip.Infof("creating new remote job queue with %d workers", size)
 
-	return q
+	return q, nil
 }
 
 // Next returns a Job from the queue. Returns a nil Job object if the

--- a/queue/remote_unordered.go
+++ b/queue/remote_unordered.go
@@ -26,7 +26,7 @@ func newRemoteUnordered(size int) remoteQueue {
 	q.dispatcher = NewDispatcher(q)
 	grip.Error(q.SetRunner(pool.NewLocalWorkers(size, q)))
 	// TODO (EVG-13540): need a way to propagate RetryHandlerOptions
-	rh, err := newRetryHandler(q, amboy.RetryHandlerOptions{})
+	rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{})
 	grip.Error(errors.Wrap(err, "could not initialize retry handler"))
 	if rh != nil {
 		grip.Error(q.SetRetryHandler(rh))

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -25,7 +25,7 @@ type basicRetryHandler struct {
 	cancelWorkers context.CancelFunc
 }
 
-func newRetryHandler(q amboy.RetryableQueue, opts amboy.RetryHandlerOptions) (amboy.RetryHandler, error) {
+func newBasicRetryHandler(q amboy.RetryableQueue, opts amboy.RetryHandlerOptions) (amboy.RetryHandler, error) {
 	if q == nil {
 		return nil, errors.New("queue cannot be nil")
 	}

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -461,3 +461,9 @@ func (q *shuffledLocal) SetRunner(r amboy.Runner) error {
 func (q *shuffledLocal) Runner() amboy.Runner {
 	return q.runner
 }
+
+func (q *shuffledLocal) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -339,3 +339,9 @@ func (q *sqsFIFOQueue) Start(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (q *sqsFIFOQueue) Close(ctx context.Context) {
+	if r := q.Runner(); r != nil {
+		r.Close(ctx)
+	}
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13540
Patch: https://evergreen.mongodb.com/version/6025b8cc0ae60674b23eac62

* Add a Close method for queues to clean up (i.e. close their worker pools, stop the retry handler).
* Add retry handler options for MongoDB queues.
* Fix one deadlock in the retry handler between the workers and Close.