### PR TITLE
EVG-14016: avoid capturing modified value in cache iterator loop and do not prune queues whose TTLs has expired

### DIFF
--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -219,7 +219,6 @@ func TestQueueGroup(t *testing.T) {
 							}
 
 							g, err := NewMongoDBSingleQueueGroup(ctx, remoteOpts, client, mopts)
-							require.NoError(t, err)
 							if test.valid && remoteTest.valid {
 								require.NoError(t, err)
 								require.NotNil(t, g)

--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -218,7 +218,8 @@ func TestQueueGroup(t *testing.T) {
 								PruneFrequency: test.ttl,
 							}
 
-							g, err := NewMongoDBSingleQueueGroup(ctx, remoteOpts, client, mopts) // nolint
+							g, err := NewMongoDBSingleQueueGroup(ctx, remoteOpts, client, mopts)
+							require.NoError(t, err)
 							if test.valid && remoteTest.valid {
 								require.NoError(t, err)
 								require.NotNil(t, g)
@@ -556,10 +557,7 @@ func TestQueueGroup(t *testing.T) {
 					for i := 0; i < 30; i++ {
 						time.Sleep(time.Second)
 
-						if ctx.Err() != nil {
-							grip.Info(ctx.Err())
-							break
-						}
+						require.NoError(t, ctx.Err())
 						if g.Len() == 0 {
 							break
 						}

--- a/queue/group_util.go
+++ b/queue/group_util.go
@@ -141,7 +141,8 @@ func (c *cacheImpl) Remove(ctx context.Context, name string) error {
 
 func (c *cacheImpl) getCacheIterUnsafe() <-chan *cacheItem {
 	out := make(chan *cacheItem, len(c.q))
-	for _, v := range c.q {
+	for k := range c.q {
+		v := c.q[k]
 		out <- &v
 	}
 	close(out)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14016

Addressing two different issues in the two MongoDB queue group implementations:
* For the single group queue (i.e. the one we use nowadays), for N items in the cache queue, the cache iterator was always returning N copies of the last item in the cache's queue rather than the N items individually.
* For the older queue (likely the legacy implementation and is unused now), every time the group queues were periodically pruned, if a queue wasn't accessed within its TTL, it would be deleted even if the queue wasn't finished processing all its jobs. In comparison, the single group implementation only prunes queues that have completed all their jobs. I'm not sure why it was implemented this way, but it means that every time we pruned the legacy queue group, it would delete all the queues even if they weren't complete. I changed the legacy queue group to stop doing this. This likely affected only my local executions because the CI tests run on `ubuntu1604-large`, which will process the queue faster than my computer, so the queues were completed before the periodic prune ran.