### PR TITLE
EVG-13540: handle retryable jobs IDs in the driver

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -95,9 +95,6 @@ type Job interface {
 type RetryableJob interface {
 	Job
 
-	// SetID allows the job ID to be modified.
-	SetID(string)
-
 	// RetryInfo reports information about the job's retry behavior.
 	RetryInfo() JobRetryInfo
 	// UpdateRetryInfo method modifies all set fields from the given options.
@@ -162,11 +159,11 @@ type JobRetryInfo struct {
 	NeedsRetry bool `bson:"needs_retry" json:"needs_retry,omitempty" yaml:"needs_retry,omitempty"`
 	// BaseJobID is the job ID of the original job that was retried, ignoring
 	// any additional retry metadata.
-	BaseJobID string `bson:"base_job_id" json:"base_job_id,omitempty" yaml:"base_job_id,omitempty"`
+	BaseJobID string `bson:"base_job_id,omitempty" json:"base_job_id,omitempty" yaml:"base_job_id,omitempty"`
 	// CurrentAttempt is the current attempt number. This is zero-indexed
 	// (unless otherwise set on enqueue), so the first time the job attempts to
 	// run, its value is 0. Each subsequent retry increments this value.
-	CurrentAttempt int `bson:"current_attempt" json:"current_attempt,omitempty" yaml:"current_attempt,omitempty"`
+	CurrentAttempt int `bson:"current_attempt,omitempty" json:"current_attempt,omitempty" yaml:"current_attempt,omitempty"`
 }
 
 // Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other

--- a/interface.go
+++ b/interface.go
@@ -160,10 +160,14 @@ type JobRetryInfo struct {
 	// NeedsRetry indicates whether the job is supposed to retry when it is
 	// complete. This will only be considered if Retryable is true.
 	NeedsRetry bool `bson:"needs_retry" json:"needs_retry,omitempty" yaml:"needs_retry,omitempty"`
-	// CurrentTrial is the current attempt number. This is zero-indexed, so the
-	// first time the job attempts to run, its value is 0. Each subsequent retry
-	// increments this value.
-	CurrentTrial int `bson:"current_trial,omitempty" json:"current_trial,omitempty" yaml:"current_trial,omitempty"`
+	// BaseJobID is the job ID of the original job that was retried, ignoring
+	// any additional retry metadata.
+	// kim: TODO: store this with the job document when doing Put().
+	BaseJobID string `bson:"base_job_id" json:"base_job_id" omitempty:"base_job_id" yaml:"base_job_id,omitempty"`
+	// CurrentAttempt is the current attempt number. This is zero-indexed, so
+	// the first time the job attempts to run, its value is 0. Each subsequent
+	// retry increments this value.
+	CurrentAttempt int `bson:"current_attempt,omitempty" json:"current_attempt,omitempty" yaml:"current_attempt,omitempty"`
 }
 
 // Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other
@@ -171,9 +175,9 @@ type JobRetryInfo struct {
 // will have the same JobRetryInfo as this one.
 func (info *JobRetryInfo) Options() JobRetryOptions {
 	return JobRetryOptions{
-		Retryable:    &info.Retryable,
-		NeedsRetry:   &info.NeedsRetry,
-		CurrentTrial: &info.CurrentTrial,
+		Retryable:      &info.Retryable,
+		NeedsRetry:     &info.NeedsRetry,
+		CurrentAttempt: &info.CurrentAttempt,
 	}
 }
 
@@ -181,9 +185,9 @@ func (info *JobRetryInfo) Options() JobRetryOptions {
 // Their meaning corresponds to the fields in JobRetryInfo, but is more amenable
 // to optional input values.
 type JobRetryOptions struct {
-	Retryable    *bool `bson:"-" json:"-" yaml:"-"`
-	NeedsRetry   *bool `bson:"-" json:"-" yaml:"-"`
-	CurrentTrial *int  `bson:"-" json:"-" yaml:"-"`
+	Retryable      *bool `bson:"-" json:"-" yaml:"-"`
+	NeedsRetry     *bool `bson:"-" json:"-" yaml:"-"`
+	CurrentAttempt *int  `bson:"-" json:"-" yaml:"-"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/job/base.go
+++ b/job/base.go
@@ -334,7 +334,7 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.NeedsRetry != nil {
 		b.retryInfo.NeedsRetry = *opts.NeedsRetry
 	}
-	if opts.CurrentTrial != nil {
-		b.retryInfo.CurrentTrial = *opts.CurrentTrial
+	if opts.CurrentAttempt != nil {
+		b.retryInfo.CurrentAttempt = *opts.CurrentAttempt
 	}
 }

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -154,19 +154,19 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 
 	trial := 5
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		CurrentTrial: utility.ToIntPtr(trial),
+		CurrentAttempt: utility.ToIntPtr(trial),
 	})
 
 	s.Require().Equal(amboy.JobRetryInfo{
-		Retryable:    true,
-		CurrentTrial: trial,
+		Retryable:      true,
+		CurrentAttempt: trial,
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable: utility.FalsePtr(),
 	})
 	s.Require().Equal(amboy.JobRetryInfo{
-		CurrentTrial: trial,
+		CurrentAttempt: trial,
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
@@ -174,7 +174,7 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 	})
 
 	s.Require().Equal(amboy.JobRetryInfo{
-		NeedsRetry:   true,
-		CurrentTrial: trial,
+		NeedsRetry:     true,
+		CurrentAttempt: trial,
 	}, s.base.RetryInfo())
 }

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -53,7 +53,6 @@ type MongoDBOptions struct {
 	DB                       string
 	GroupName                string
 	UseGroups                bool
-	UseRetries               bool
 	Priority                 bool
 	CheckWaitUntil           bool
 	CheckDispatchBy          bool

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -15,8 +15,13 @@ type remoteQueueDriver interface {
 	Open(context.Context) error
 	Close()
 
-	// Get finds a job by job ID.
+	// Get finds a job by job ID. For retryable jobs, this returns the latest
+	// job attempt.
 	Get(context.Context, string) (amboy.Job, error)
+	// GetAttempt returns a job by job ID and attempt number. Only applicable to
+	// retryable jobs. If used for a non-retryable job, this should return nil
+	// and an error.
+	GetAttempt(ctx context.Context, id string, attempt int) (amboy.RetryableJob, error)
 	// Put inserts a new job in the backing storage.
 	Put(context.Context, amboy.Job) error
 	// Save updates an existing job in the backing storage. Implementations may
@@ -48,6 +53,7 @@ type MongoDBOptions struct {
 	DB                       string
 	GroupName                string
 	UseGroups                bool
+	UseRetries               bool
 	Priority                 bool
 	CheckWaitUntil           bool
 	CheckDispatchBy          bool

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -238,6 +238,19 @@ func (d *mongoDriver) queueIndexes() []mongo.IndexModel {
 			},
 			Options: options.Index().SetSparse(true).SetUnique(true),
 		},
+		{
+			Keys: bsonx.Doc{
+				{
+					Key:   "retry_info.base_job_id",
+					Value: bsonx.Int32(1),
+				},
+				{
+					Key:   "retry_info.current_attempt",
+					Value: bsonx.Int32(-1),
+				},
+			},
+			Options: options.Index().SetUnique(true),
+		},
 	}
 
 	if d.opts.TTL > 0 {
@@ -250,22 +263,6 @@ func (d *mongoDriver) queueIndexes() []mongo.IndexModel {
 				},
 			},
 			Options: options.Index().SetExpireAfterSeconds(ttl),
-		})
-	}
-
-	if d.opts.UseRetries {
-		indexes = append(indexes, mongo.IndexModel{
-			Keys: bsonx.Doc{
-				{
-					Key:   "retry_info.base_job_id",
-					Value: bsonx.Int32(1),
-				},
-				{
-					Key:   "retry_info.current_attempt",
-					Value: bsonx.Int32(-1),
-				},
-			},
-			Options: options.Index().SetUnique(true),
 		})
 	}
 

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -400,9 +400,6 @@ func (d *mongoDriver) getIDWithGroup(name string) string {
 }
 
 func (d *mongoDriver) addMetadata(j *registry.JobInterchange) {
-	if j.RetryInfo.Retryable {
-		j.RetryInfo.BaseJobID = j.Name
-	}
 	d.addRetryToMetadata(j)
 	d.addGroupToMetadata(j)
 }
@@ -434,6 +431,7 @@ func (d *mongoDriver) addRetryToMetadata(j *registry.JobInterchange) {
 		return
 	}
 
+	j.RetryInfo.BaseJobID = j.Name
 	j.Name = buildCompoundID(retryAttemptPrefix(j.RetryInfo.CurrentAttempt), j.Name)
 }
 
@@ -717,8 +715,6 @@ func (d *mongoDriver) Jobs(ctx context.Context) <-chan amboy.Job {
 
 				continue
 			}
-
-			d.removeMetadata(ji)
 
 			var job amboy.Job
 			job, err = ji.Resolve(d.opts.Format)

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -265,7 +265,6 @@ func (d *mongoDriver) queueIndexes() []mongo.IndexModel {
 					Value: bsonx.Int32(-1),
 				},
 			},
-			// kim: QUESTION: should this be unique? It seems like it should be.
 			Options: options.Index().SetUnique(true),
 		})
 	}

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -382,21 +382,24 @@ func (d *mongoDriver) getIDFromName(name string) string {
 	return name
 }
 
-func (d *mongoDriver) processNameForUsers(j *registry.JobInterchange) {
-	if !d.opts.UseGroups {
+func (d *mongoDriver) removeRetryFromID(j *registry.JobInterchange) {
+	if !j.RetryInfo.Retryable {
 		return
 	}
 
-	j.Name = j.Name[len(d.opts.GroupName)+1:]
+	prefix := retryAttemptPrefix(j.RetryInfo.CurrentAttempt)
+
+	j.Name = j.Name[len(prefix)+1:]
 }
 
-func (d *mongoDriver) processJobForGroup(j *registry.JobInterchange) {
-	if !d.opts.UseGroups {
+func (d *mongoDriver) addRetryToID(j *registry.JobInterchange) {
+	if !d.opts.UseRetries {
 		return
 	}
-
-	j.Group = d.opts.GroupName
-	j.Name = buildCompoundID(d.opts.GroupName, j.Name)
+	if !j.RetryInfo.Retryable {
+		return
+	}
+	j.Name = buildCompoundID(retryAttemptPrefix(j.RetryInfo.CurrentAttempt), j.Name)
 }
 
 func (d *mongoDriver) modifyQueryForGroup(q bson.M) {

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -452,8 +452,8 @@ func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 func (s *DriverSuite) TestJobsMethodReturnsAllJobs() {
 	mocks := make(map[string]*job.ShellJob)
 
-	for idx := range [24]int{} {
-		name := fmt.Sprintf("echo test num %d", idx)
+	for i := 0; i < 24; i++ {
+		name := fmt.Sprintf("echo test num %d", i)
 		j := job.NewShellJob(name, "")
 		s.NoError(s.driver.Put(s.ctx, j))
 		mocks[j.ID()] = j

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/google/uuid"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
@@ -198,15 +199,88 @@ func (s *DriverSuite) TestSaveJobPersistsJobInDriver() {
 	s.Equal(1, s.driver.Stats(s.ctx).Total)
 }
 
-/*
-kim: TODO:
-- Put then Get on retryable job returns the only doc when it's there.
-- Put then Get on retryable job returns latest.
-- Put then GetAttempt on retryable job returns attempt doc.
-- Put then GetAttempt on non-retryable job fails.
-*/
+func (s *DriverSuite) TestPutAndGetJobRoundtripsSingleRetryableJob() {
+	j := newMockRetryableJob("id")
 
-func (s *DriverSuite) TestSaveAndGetRoundTripObjects() {
+	s.Require().NoError(s.driver.Put(s.ctx, j))
+
+	storedJob, err := s.driver.Get(s.ctx, j.ID())
+	s.Require().NoError(err)
+
+	storedRetryJob, ok := storedJob.(amboy.RetryableJob)
+	s.Require().True(ok)
+
+	s.Equal(j.ID(), storedRetryJob.ID())
+	s.Equal(j.RetryInfo(), storedRetryJob.RetryInfo())
+
+	s.Equal(1, s.driver.Stats(s.ctx).Total)
+}
+
+func (s *DriverSuite) TestPutAndGetJobRoundtripsLatestRetryableJob() {
+	j0 := newMockRetryableJob("id")
+	jobID := j0.ID()
+	j1 := newMockRetryableJob("id")
+	j1.UpdateRetryInfo(amboy.JobRetryOptions{
+		CurrentAttempt: utility.ToIntPtr(1),
+	})
+	j2 := newMockRetryableJob("id")
+	j2.UpdateRetryInfo(amboy.JobRetryOptions{
+		CurrentAttempt: utility.ToIntPtr(2),
+	})
+
+	s.Require().NoError(s.driver.Put(s.ctx, j1))
+	s.Require().NoError(s.driver.Put(s.ctx, j0))
+	s.Require().NoError(s.driver.Put(s.ctx, j2))
+
+	storedJob, err := s.driver.Get(s.ctx, jobID)
+	s.Require().NoError(err)
+
+	storedRetryJob, ok := storedJob.(amboy.RetryableJob)
+	s.Require().True(ok)
+
+	s.Equal(jobID, storedRetryJob.ID())
+	s.Equal(j2.RetryInfo(), storedRetryJob.RetryInfo())
+
+	s.Equal(3, s.driver.Stats(s.ctx).Total)
+}
+
+func (s *DriverSuite) TestPutAndGetAttemptRoundtripsRetryableJob() {
+	var jobs []amboy.RetryableJob
+	var jobID string
+	for i := 0; i < 3; i++ {
+		j := newMockRetryableJob("id")
+		jobID = j.ID()
+		j.UpdateRetryInfo(amboy.JobRetryOptions{
+			CurrentAttempt: utility.ToIntPtr(i),
+		})
+		s.Require().NoError(s.driver.Put(s.ctx, j))
+	}
+
+	for _, j := range jobs {
+		storedJob, err := s.driver.GetAttempt(s.ctx, jobID, j.RetryInfo().CurrentAttempt)
+		s.Require().NoError(err)
+
+		storedRetryJob, ok := storedJob.(amboy.RetryableJob)
+		s.Require().True(ok)
+
+		s.Equal(jobID, j.ID())
+		s.Equal(jobID, storedRetryJob.ID())
+		s.Equal(j.RetryInfo().CurrentAttempt, storedJob.RetryInfo().CurrentAttempt)
+	}
+	s.Equal(3, s.driver.Stats(s.ctx).Total)
+}
+
+func (s *DriverSuite) TestPutAndGetAttemptOnNonretryableJobFails() {
+	j := newMockJob()
+	j.SetID("foo")
+	s.Require().NoError(s.driver.Put(s.ctx, j))
+
+	storedJob, err := s.driver.GetAttempt(s.ctx, j.ID(), 0)
+	s.Error(err)
+	s.Zero(storedJob)
+}
+
+func (s *DriverSuite) TestPutAndGetRoundTripObjects() {
 	j := job.NewShellJob("echo foo", "")
 	name := j.ID()
 

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -198,6 +198,14 @@ func (s *DriverSuite) TestSaveJobPersistsJobInDriver() {
 	s.Equal(1, s.driver.Stats(s.ctx).Total)
 }
 
+/*
+kim: TODO:
+- Put then Get on retryable job returns the only doc when it's there.
+- Put then Get on retryable job returns latest.
+- Put then GetAttempt on retryable job returns attempt doc.
+- Put then GetAttempt on non-retryable job fails.
+*/
+
 func (s *DriverSuite) TestSaveAndGetRoundTripObjects() {
 	j := job.NewShellJob("echo foo", "")
 	name := j.ID()

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -21,7 +21,7 @@ func init() {
 	mockJobCounters = &mockJobRunEnv{}
 	registry.AddJobType("mock", func() amboy.Job { return newMockJob() })
 	registry.AddJobType("sleep", func() amboy.Job { return newSleepJob() })
-	registry.AddJobType("retryable", func() amboy.Job { return &mockRetryableJob{} })
+	registry.AddJobType("mock-retryable", func() amboy.Job { return makeMockRetryableJob() })
 }
 
 // mockRetryableQueue provides a mock implementation of a remoteQueue whose
@@ -181,12 +181,24 @@ type mockRetryableJob struct {
 	op                func()
 }
 
+func makeMockRetryableJob() *mockRetryableJob {
+	j := &mockRetryableJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    "mock-retryable",
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
 func newMockRetryableJob(id string) *mockRetryableJob {
-	j := &mockRetryableJob{}
+	j := makeMockRetryableJob()
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable: utility.TruePtr(),
 	})
-	j.SetDependency(dependency.NewAlways())
 	j.SetID(fmt.Sprintf("mock-retryable-%s", id))
 	return j
 }

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -92,6 +92,25 @@ func (q *remoteBase) Get(ctx context.Context, name string) (amboy.Job, bool) {
 	return job, true
 }
 
+func (q *remoteBase) GetAttempt(ctx context.Context, name string, attempt int) (amboy.RetryableJob, bool) {
+	if q.driver == nil {
+		return nil, false
+	}
+
+	j, err := q.driver.GetAttempt(ctx, name, attempt)
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"driver":  q.driver.ID(),
+			"type":    q.driverType,
+			"name":    name,
+			"attempt": attempt,
+		}))
+		return nil, false
+	}
+
+	return j, true
+}
+
 func (q *remoteBase) jobServer(ctx context.Context) {
 	grip.Info("starting queue job server for remote queue")
 

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -255,5 +256,5 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 }
 
 func retryAttemptPrefix(attempt int) string {
-	return "attempt-%d"
+	return fmt.Sprintf("attempt-%d", attempt)
 }

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -243,14 +243,14 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 	// TODO (EVG-13540): ensure this is correct for grouped jobs (i.e. it may
 	// trim the grouped job ID off, which we have to make sure gets re-added
 	// before it's persisted).
-	id := makeRetryJobID(newJob.ID(), newInfo.CurrentTrial)
+	id := makeRetryJobID(newJob.ID(), newInfo.CurrentAttempt)
 	if id == "" {
 		return nil
 	}
 	newJob.SetID(id)
 	newInfo.NeedsRetry = false
 	newInfo.Retryable = false
-	newInfo.CurrentTrial++
+	newInfo.CurrentAttempt++
 	newJob.UpdateRetryInfo(newInfo.Options())
 
 	err := rh.queue.SaveAndPut(ctx, j, newJob)

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -2,8 +2,6 @@ package queue
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -240,14 +238,6 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 	oldInfo.Retryable = false
 	j.UpdateRetryInfo(oldInfo.Options())
 
-	// TODO (EVG-13540): ensure this is correct for grouped jobs (i.e. it may
-	// trim the grouped job ID off, which we have to make sure gets re-added
-	// before it's persisted).
-	id := makeRetryJobID(newJob.ID(), newInfo.CurrentAttempt)
-	if id == "" {
-		return nil
-	}
-	newJob.SetID(id)
 	newInfo.NeedsRetry = false
 	newInfo.Retryable = false
 	newInfo.CurrentAttempt++
@@ -264,15 +254,6 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 	return nil
 }
 
-// makeRetryJobID creates the job ID for the retry job.
-func makeRetryJobID(id string, currAttempt int) string {
-	currAttemptSuffix := fmt.Sprintf(".attempt-%d", currAttempt)
-	if currAttempt != 0 && !strings.HasSuffix(id, currAttemptSuffix) {
-		// If the job has already been retried once but doesn't have the
-		// expected suffix applied by the retry handler, the job ID is in an
-		// invalid format.
-		return ""
-	}
-
-	return fmt.Sprintf("%s.attempt-%d", strings.TrimSuffix(id, currAttemptSuffix), currAttempt+1)
+func retryAttemptPrefix(attempt int) string {
+	return "attempt-%d"
 }

--- a/queue/util.go
+++ b/queue/util.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// RandomString returns a cryptographically random string.
+// randomString returns a cryptographically random string.
 func randomString(x int) string {
 	b := make([]byte, x)
 	_, _ = rand.Read(b) // nolint

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -187,8 +187,8 @@ func (s *JobInterchangeSuite) TestApplyScopesOnEnqueuePersists() {
 
 func (s *JobInterchangeSuite) TestRetryInfoPersists() {
 	info := amboy.JobRetryInfo{
-		Retryable:    true,
-		CurrentTrial: 5,
+		Retryable:      true,
+		CurrentAttempt: 5,
 	}
 	s.job.UpdateRetryInfo(info.Options())
 	s.Equal(info, s.job.RetryInfo())

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -179,7 +179,7 @@ func (j *JobTest) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.NeedsRetry != nil {
 		j.Retry.NeedsRetry = *opts.NeedsRetry
 	}
-	if opts.CurrentTrial != nil {
-		j.Retry.CurrentTrial = *opts.CurrentTrial
+	if opts.CurrentAttempt != nil {
+		j.Retry.CurrentAttempt = *opts.CurrentAttempt
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13540
Patch: https://evergreen.mongodb.com/version/602c406ec9ec445b6f7bcd8c

# Background
Jobs in queue groups are basically the same as regular ungrouped jobs, but they have the group name prepended to them (i.e. the `_id` format is `${groupName}.${jobID}`). The driver deals with adding the group name when it goes into the DB and when queries are made on a queue group, the driver handles re-adding the group name to the query, so that the Amboy end user never has to deal with a grouped job queue differently from a regular job queue.

Since each retry job needs to have a unique `_id`, I originally just glommed the attempt number at the end of the job ID in the retry handler. However, this makes it hard to get jobs out of the driver (e.g. for the Nth job attempt, you would have to call `(amboy.Queue).Get("${myJobID}.attempt-${N}")`. Instead, I changed it so that the driver deals with the `_id` manipulation for retryable jobs. The number is now a prefix and the driver deals with appending/removing the attempt just like how it does for jobs in queue groups. Now `Get("${myJobID}")` will return the latest job attempt for the given job ID.

For a regular job, the `_id` in the DB is still `${myJobID}`.
For a retryable job, the `_id` in the DB is now `attempt-${N}.${myJobID}`.
For a retryable job in a group queue, the `_id` in the DB is now `${groupName}.attempt-${N}.${myJobID}`.

# Changes
* Rename `CurrentTrial` to `CurrentAttempt` to make the naming consistent.
* Move retry `_id` handling logic out of the retry handler and into the driver.
* `Get()` works the same as before. If it's passed a job ID for a retryable job, it returns the latest job attempt.
* Add new `GetAttempt()` to get the Nth attempt of a job rather than the latest.
* Rename some group-handling helper functions and combine them with retry attempt-handling helper functions.
* Remove some places where the group is unnecessarily removed from the job interchange name (it's not necessarily wrong, but it doesn't do anything so I would prefer to simplify it).
* Do some variable renaming in the driver for clarification, because `j` and `job` are used inconsistently between `Job`s and `JobInterchange`s.