### PR TITLE
EVG-13540: add unit and integration tests for retry handler

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -163,7 +163,7 @@ type JobRetryInfo struct {
 	// CurrentAttempt is the current attempt number. This is zero-indexed
 	// (unless otherwise set on enqueue), so the first time the job attempts to
 	// run, its value is 0. Each subsequent retry increments this value.
-	CurrentAttempt int `bson:"current_attempt,omitempty" json:"current_attempt,omitempty" yaml:"current_attempt,omitempty"`
+	CurrentAttempt int `bson:"current_attempt" json:"current_attempt,omitempty" yaml:"current_attempt,omitempty"`
 }
 
 // Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other

--- a/interface.go
+++ b/interface.go
@@ -333,7 +333,7 @@ type RetryableQueue interface {
 	// SaveAndPut saves an existing job toSave in the queue (see Save) and
 	// inserts a new job toPut in the queue (see Put). Implementations must
 	// make this operation atomic.
-	SaveAndPut(ctx context.Context, toSave, toPut RetryableJob) error
+	SaveAndPut(ctx context.Context, toSave, toPut Job) error
 }
 
 // RetryHandler provides a means to retry RetryableJobs within a RetryableQueue.

--- a/interface.go
+++ b/interface.go
@@ -342,15 +342,14 @@ type RetryHandler interface {
 	// should be retried. Implementations may not be able to change their Queue
 	// association after starting.
 	SetQueue(RetryableQueue) error
-	// Start prepares the retry handler to begin processing jobs to retry.
+	// Start prepares the RetryHandler to begin processing jobs to retry.
 	Start(context.Context) error
 	// Started reports if the RetryHandler has started.
 	Started() bool
-	// Close aborts all retry work in progress and waits for all work to be
-	// return.
-	Close(context.Context)
-	// Put adds a job that must be retried to the retry handler.
+	// Put adds a job that must be retried into the RetryHandler.
 	Put(context.Context, RetryableJob) error
+	// Close aborts all retry work in progress and waits for all work to finish.
+	Close(context.Context)
 }
 
 // RetryHandlerOptions configures the behavior of a RetryHandler.

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1037,6 +1037,7 @@ func (d *mongoDriver) tryDispatchJob(ctx context.Context, iter *mongo.Cursor, st
 			)
 			continue
 		}
+
 		return j, dispatchInfo
 	}
 

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -103,8 +103,10 @@ func (q *mockRemoteQueue) Driver() remoteQueueDriver {
 }
 
 func (q *mockRemoteQueue) SetDriver(d remoteQueueDriver) error {
+	if err := q.remoteQueue.SetDriver(d); err != nil {
+		return err
+	}
 	q.driver = d
-	q.remoteQueue.SetDriver(d)
 	q.driver.SetDispatcher(q.dispatcher)
 	return nil
 }

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -224,19 +224,6 @@ func makeMockRetryableJob() *mockRetryableJob {
 	return j
 }
 
-func makeMockRetryableJob() *mockRetryableJob {
-	j := &mockRetryableJob{
-		Base: job.Base{
-			JobType: amboy.JobType{
-				Name:    "mock-retryable",
-				Version: 0,
-			},
-		},
-	}
-	j.SetDependency(dependency.NewAlways())
-	return j
-}
-
 func newMockRetryableJob(id string) *mockRetryableJob {
 	j := makeMockRetryableJob()
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
@@ -259,7 +246,7 @@ func (j *mockRetryableJob) Run(ctx context.Context) {
 		j.UpdateRetryInfo(*j.UpdatedRetryInfo)
 	}
 
-	if j.NumTimesToRetry != 0 && j.RetryInfo().CurrentTrial < j.NumTimesToRetry {
+	if j.NumTimesToRetry != 0 && j.RetryInfo().CurrentAttempt < j.NumTimesToRetry {
 		j.NumTimesToRetry++
 		j.UpdateRetryInfo(amboy.JobRetryOptions{
 			NeedsRetry: utility.TruePtr(),

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -70,14 +70,14 @@ func newMockRemoteQueue(opts mockRemoteQueueOptions) (*mockRemoteQueue, error) {
 	}
 	mq := &mockRemoteQueue{remoteQueue: opts.queue}
 	if opts.driver != nil {
-		if err := opts.queue.SetDriver(opts.driver); err != nil {
+		if err := mq.SetDriver(opts.driver); err != nil {
 			return nil, errors.Wrap(err, "configuring queue with driver")
 		}
 	}
 	if opts.makeDispatcher != nil {
 		mq.dispatcher = opts.makeDispatcher(mq)
 		if opts.driver != nil {
-			opts.driver.SetDispatcher(mq.dispatcher)
+			mq.driver.SetDispatcher(mq.dispatcher)
 		}
 	}
 	if opts.makeRetryHandler != nil {
@@ -101,6 +101,7 @@ func (q *mockRemoteQueue) Driver() remoteQueueDriver {
 
 func (q *mockRemoteQueue) SetDriver(d remoteQueueDriver) error {
 	q.driver = d
+	q.remoteQueue.SetDriver(d)
 	q.driver.SetDispatcher(q.dispatcher)
 	return nil
 }

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -37,6 +37,7 @@ type mockRemoteQueue struct {
 	// Mockable methods
 	putJob        func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	getJob        func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
+	getJobAttempt func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.RetryableJob, bool)
 	saveJob       func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	saveAndPutJob func(ctx context.Context, q remoteQueue, toSave, toPut amboy.Job) error
 	nextJob       func(ctx context.Context, q remoteQueue) amboy.Job
@@ -127,6 +128,13 @@ func (q *mockRemoteQueue) Get(ctx context.Context, id string) (amboy.Job, bool) 
 		return q.getJob(ctx, q.remoteQueue, id)
 	}
 	return q.remoteQueue.Get(ctx, id)
+}
+
+func (q *mockRemoteQueue) GetAttempt(ctx context.Context, id string, attempt int) (amboy.RetryableJob, bool) {
+	if q.getJobAttempt != nil {
+		return q.getJobAttempt(ctx, q.remoteQueue, id, attempt)
+	}
+	return q.remoteQueue.GetAttempt(ctx, id, attempt)
 }
 
 func (q *mockRemoteQueue) Save(ctx context.Context, j amboy.Job) error {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1164,10 +1164,10 @@ func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 			require.True(t, ok)
 			assert.True(t, rj.RetryInfo().Retryable)
 			assert.False(t, rj.RetryInfo().NeedsRetry)
-			if rj.RetryInfo().CurrentTrial == 0 {
+			if rj.RetryInfo().CurrentAttempt == 0 {
 				foundFirstAttempt = true
 			}
-			if rj.RetryInfo().CurrentTrial == 1 {
+			if rj.RetryInfo().CurrentAttempt == 1 {
 				foundSecondAttempt = true
 			}
 		}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1102,3 +1102,5 @@ func ApplyScopesOnEnqueueTest(bctx context.Context, t *testing.T, test QueueTest
 		})
 	}
 }
+
+// TODO (EVG-13540): write integration tests with remoteQueue and RetryHandler.

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -161,7 +161,7 @@ func (q *remoteBase) Save(ctx context.Context, j amboy.Job) error {
 	return q.driver.Save(ctx, j)
 }
 
-func (q *remoteBase) SaveAndPut(ctx context.Context, toSave, toPut amboy.RetryableJob) error {
+func (q *remoteBase) SaveAndPut(ctx context.Context, toSave, toPut amboy.Job) error {
 	return q.driver.SaveAndPut(ctx, toSave, toPut)
 }
 

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -115,7 +115,7 @@ func (rh *basicRetryHandler) Put(ctx context.Context, j amboy.RetryableJob) erro
 
 func (rh *basicRetryHandler) Close(ctx context.Context) {
 	rh.mu.Lock()
-	if !rh.Started() {
+	if !rh.started {
 		rh.mu.Unlock()
 		return
 	}

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -46,6 +46,10 @@ func (rh *basicRetryHandler) Start(ctx context.Context) error {
 		return nil
 	}
 
+	if rh.queue == nil {
+		return errors.New("cannot start retry handler without a queue")
+	}
+
 	rh.started = true
 
 	workerCtx, workerCancel := context.WithCancel(ctx)

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -159,7 +159,6 @@ func (rh *basicRetryHandler) waitForJob(ctx context.Context) error {
 			// Once the job has been processed (either success or failure),
 			// mark it as processed so it does not attempt to retry again.
 			j.UpdateRetryInfo(amboy.JobRetryOptions{
-				Retryable:  utility.FalsePtr(),
 				NeedsRetry: utility.FalsePtr(),
 			})
 			// TODO (EVG-13540): this has to retry this op until success,
@@ -225,6 +224,7 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		if !ok {
 			return errors.New("could not find job")
 		}
+
 		newJob, ok := reloadJob.(amboy.RetryableJob)
 		if !ok {
 			return errors.New("job is not retryable")
@@ -246,7 +246,6 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		}
 
 		newInfo.NeedsRetry = false
-		newInfo.Retryable = false
 		newInfo.CurrentAttempt++
 		newJob.UpdateRetryInfo(newInfo.Options())
 

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -115,6 +115,10 @@ func (rh *basicRetryHandler) Put(ctx context.Context, j amboy.RetryableJob) erro
 
 func (rh *basicRetryHandler) Close(ctx context.Context) {
 	rh.mu.Lock()
+	if !rh.Started() {
+		rh.mu.Unlock()
+		return
+	}
 	if rh.cancelWorkers != nil {
 		rh.cancelWorkers()
 	}

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -328,3 +328,52 @@ func TestRetryHandlerImplementations(t *testing.T) {
 		})
 	}
 }
+
+// func TestRetryHandlerQueueIntegration(t *testing.T) {
+
+// }
+
+// func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
+// 	q, closer, err := test.Constructor(bctx, newDriverID(), size.Size)
+// 	require.NoError(t, err)
+// 	defer func() {
+// 		assert.NoError(t, closer(bctx))
+// 	}()
+// 	_, ok := q.(amboy.RetryableQueue)
+// 	require.True(t, ok, "queue is not retryable")
+//
+// 	/*
+// 		kim: TODO: test:
+// 		- mock retryable job sets needs retry on the first attempt and re-enqueues itself. Second job is identical except for things like NeedsRetry/CurrentAttempt
+// 		- mock retryable job does not set needs retry and does not re-enqueue.
+// 		- mock retryable job updates retry info to need retry and re-enqueues.
+// 		- mock retryable job updates retry info with different current attempt, and it fails to re-enqueue.
+// 	*/
+// 	// for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, q amboy.RetryableQueue){
+// 	//     // "": func(ctx context.Context, t *testing.T, q amboy.RetryableQueue) {},
+// 	//     // "": func(ctx context.Context, t *testing.T, q amboy.RetryableQueue) {},
+// 	//     // "": func(ctx context.Context, t *testing.T, q amboy.RetryableQueue) {},
+// 	//     // "": func(ctx context.Context, t *testing.T, q amboy.RetryableQueue) {},
+// 	// } {
+// 	//     t.Run(testName, func(t *testing.T) {
+// 	//         ctx, cancel := context.WithTimeout(bctx, time.Minute)
+// 	//         defer cancel()
+// 	//
+// 	//         q, closer, err := test.Constructor(ctx, newDriverID(), size.Size)
+// 	//         require.NoError(t, err)
+// 	//         defer func() {
+// 	//             assert.NoError(t, closer(ctx))
+// 	//         }()
+// 	//         require.NoError(t, runner.SetPool(q, size.Size))
+// 	//
+// 	//         require.NoError(t, q.Start(ctx))
+// 	//
+// 	//         amboy.WithRetryableQueue(q, func(rq amboy.RetryableQueue) {
+// 	//             rh, err := newBasicRetryHandler(rq, amboy.RetryHandlerOptions{})
+// 	//             require.NoError(t, err)
+// 	//             require.NoError(t, rq.SetRetryHandler(rh))
+// 	//             testCase(ctx, t, rq)
+// 	//         })
+// 	//     })
+// 	// }
+// }

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -1,0 +1,128 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/mongodb/amboy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBasicRetryHandler(t *testing.T) {
+	q, err := newRemoteUnordered(1)
+	require.NoError(t, err)
+	t.Run("SucceedsWithQueue", func(t *testing.T) {
+		rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{})
+		assert.NoError(t, err)
+		assert.NotZero(t, rh)
+	})
+	t.Run("FailsWithNilQueue", func(t *testing.T) {
+		rh, err := newBasicRetryHandler(nil, amboy.RetryHandlerOptions{})
+		assert.Error(t, err)
+		assert.Zero(t, rh)
+	})
+	t.Run("FailsWithInvalidOptions", func(t *testing.T) {
+		rh, err := newBasicRetryHandler(q, amboy.RetryHandlerOptions{NumWorkers: -1})
+		assert.Error(t, err)
+		assert.Zero(t, rh)
+	})
+}
+
+// kim: TODO: unit test the retry handler with the mockRemoteQueue
+func TestRetryHandlerImplementations(t *testing.T) {
+	// kim: TODO: setup
+	// newMockRemoteQueue(nil options)
+	// Set mock methods to return dummy results needed, without actually
+	// modifying DB state at all.
+
+	/*
+		kim: TODO: test:
+		- Retry handler fails in Start() without prior SetQueue()
+		- SetQueue() fails after Start()
+		- Started() is true after Start().
+		- Close() succeeds without start and stops all workers.
+		- Close() succeeds after start.
+		- Close() is safe to call multiple times.
+		- Put() succeeds on unstarted RetryHandler but doesn't trigger re-enqueue due to no workers
+		- Put() succeeds on already-started RetryHandler and triggers re-enqueue from workers
+		- Put() on closed RetryHandler doesn't trigger re-enqueue due to no workers.
+		- Also need to test functionality of options.
+	*/
+}
+
+// TestBasicRetryHandler tests functionality specific to the basicRetryHandler
+// implementation.
+func TestBasicRetryHandler(t *testing.T) {
+	// kim: TODO: setup
+	// newMockRemoteQueue(nil options)
+	// Set mock methods to return dummy results needed, without actually
+	// modifying DB state at all.
+	/*
+		kim: TODO: test:
+		- tryEnqueueJob() reloads the job from the queue (mock Get() so that it just roundtrips the in-memory job).
+		- tryEnqueueJob() fails when job cannot be reloaded from the queue.
+		- tryEnqueueJob() fails if the job it gets back is not retryable (mock Get() so that it returns a regular non-retryable job).
+		- tryEnqueueJob() no-ops if the reloaded job doesn't need to retry.
+		- tryEnqueueJob() fails if the old retry info does not match the reloaded retry info (i.e. the job's persistent state changed).
+		- tryEnqueueJob() fails if SaveAndPut() fails.
+		- tryEnqueueJob() no-ops if SaveAndPut() returns duplicate job error.
+		- tryEnqueueJob() succeeds and updates retry info of old and new job (check mock queue for expected calls and persistent state changes for old/new job state).
+		- tryEnqueueJob() no-ops if the old job ID is invalid (i.e. doesn't have ".attempt-${attempt_num}")
+		- When handleJob() fails to enqueue once, it tries again.
+		- When handleJob() exceeds MaxRetryAttempts, it gives up.
+		- When handleJob() exceeds MaxRetryTime, it gives up.
+		- When context errors, waitForJob() stops.
+		- When waitForJob() receives no job, it no-ops.
+		- When waitForJob() receives a job, it attempts to enqueue it (requires mock queue)
+		- When waitForJob() does not initially receive a job, it sleeps for RetryBackoff duration, then receives a job and enqueues it.
+	*/
+}
+
+// kim: TODO: write these once there's a mock queue to use and introspect.
+// func TestQueueRetryHandlerIntegration(t *testing.T) {
+//     ctx, cancel := context.WithCancel(context.Background())
+//     defer cancel()
+//     // kim: TODO: populate options
+//     dbOpts := MongoDBQueueCreationOptions{}
+//     for queueName, makeQueue := range map[string]func(ctx context.Context, t *testing.T) remoteQueue{
+//         // kim: TODO: need to propagate options to these
+//         "MongoUnordered": func(ctx context.Context, t *testing.T) remoteQueue {
+//             rq, err := NewMongoDBQueue(ctx, dbOpts)
+//             require.NoError(t, err)
+//             return rq
+//         },
+//         "MongoOrdered": func(ctx context.Context, t *testing.T) remoteQueue {
+//             rq, err := NewMongoDBQueue(ctx, dbOpts)
+//             require.NoError(t, err)
+//             return rq
+//         },
+//     } {
+//         t.Run(queueName, func(t *testing.T) {
+//             for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue){
+//                 "InitializesUnstarted": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {
+//                     rq := makeMockQueue(ctx, t)
+//                     rh := rq.RetryHandler()
+//                     require.NotZero(t, rh)
+//                     assert.False(t, rh.Started())
+//                 },
+//                 "": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {},
+//                 // "": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {},
+//                 // "": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {},
+//                 // "": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {},
+//                 // "": func(ctx context.Context, t *testing.T, makeMockQueue func(ctx context.Context, t *testing.T) *mockRemoteQueue) {},
+//             } {
+//                 t.Run(testName, func(t *testing.T) {
+//                     tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+//                     defer tcancel()
+//					   makeMockQueue := func(ctx context.Context, t *testing.T) {
+//						   q := makeQueue(ctx, t)
+//						   mq, err := newMockRemoteQueue(mockRemoteQueueOptions{queue: q})
+//						   require.NoError(t, err)
+//					       return mq
+//					   }
+//                     testCase(tctx, t, makeMockQueue)
+//                 })
+//             }
+//         })
+//     }
+// }

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -148,14 +148,14 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						}
 						assert.False(t, oldJob.RetryInfo().NeedsRetry)
 						// kim: TODO: update once PR is merged
-						assert.Zero(t, oldJob.RetryInfo().CurrentTrial)
+						assert.Zero(t, oldJob.RetryInfo().CurrentAttempt)
 
 						newJob, ok := toPut.(amboy.RetryableJob)
 						if !ok {
 							return errors.New("expected retryable job")
 						}
 						assert.False(t, newJob.RetryInfo().NeedsRetry)
-						assert.Equal(t, 1, newJob.RetryInfo().CurrentTrial)
+						assert.Equal(t, 1, newJob.RetryInfo().CurrentAttempt)
 
 						return nil
 					}

--- a/stats.go
+++ b/stats.go
@@ -13,7 +13,7 @@ import (
 // provides a common format for different Queue implementations to
 // report on their state.
 //
-// Implement's grip's message.Composer interface when passed as a
+// Implements grip's message.Composer interface when passed as a
 // pointer.
 type QueueStats struct {
 	Running   int            `bson:"running" json:"running" yaml:"running"`


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13540

* Add unit testing and integration testing for the retry handler.
* Make some minor fixes to the retry handler around locking, restoring in-memory job state, and loading the job from the DB.