### PR TITLE
EVG-13540: make retry handler more robust

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -332,9 +332,10 @@ type RetryableQueue interface {
 	// and a bool indicating whether the job was found or not.
 	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)
 
-	// CompleteAndPut saves an existing job toComplete in the queue (see Save) and
-	// inserts a new job toPut in the queue (see Put). Implementations must
-	// make this operation atomic.
+	// CompleteAndPut marks an existing job toComplete in the queue (see
+	// CompleteRetry) as finished processing its retry and inserts a new job
+	// toPut in the queue (see Put). Implementations must make this operation
+	// atomic.
 	CompleteAndPut(ctx context.Context, toComplete, toPut Job) error
 
 	// CompleteRetry marks a job that needs to retry as finished processing, so

--- a/interface.go
+++ b/interface.go
@@ -332,11 +332,10 @@ type RetryableQueue interface {
 	// and a bool indicating whether the job was found or not.
 	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)
 
-	// kim: TODO: rename to CompleteAndPut
-	// SaveAndPut saves an existing job toSave in the queue (see Save) and
+	// CompleteAndPut saves an existing job toComplete in the queue (see Save) and
 	// inserts a new job toPut in the queue (see Put). Implementations must
 	// make this operation atomic.
-	SaveAndPut(ctx context.Context, toSave, toPut Job) error
+	CompleteAndPut(ctx context.Context, toComplete, toPut Job) error
 
 	// CompleteRetry marks a job that needs to retry as finished processing, so
 	// that it will no longer retry.

--- a/interface.go
+++ b/interface.go
@@ -366,6 +366,9 @@ type RetryHandlerOptions struct {
 	// NumWorkers is the maximum number of jobs that are allowed to retry in
 	// parallel.
 	NumWorkers int
+	// WorkerCheckInterval is the time interval retry workers will wait before
+	// attempting to pick up another job to retry.
+	WorkerCheckInterval time.Duration
 }
 
 func (opts *RetryHandlerOptions) Validate() error {

--- a/interface.go
+++ b/interface.go
@@ -79,8 +79,10 @@ type Job interface {
 	Lock(owner string, lockTimeout time.Duration) error
 	Unlock(owner string, lockTimeout time.Duration)
 
-	// Scope provides the ability to provide more configurable
-	// exclusion a job can provide.
+	// Scope provides the ability to configure mutual exclusion for a job in a
+	// queue. When called, these methods do not actually take a lock; rather,
+	// they signal the intention to lock within the queue. It is invalid for end
+	// users to call SetScopes after the job has already dispatched.
 	Scopes() []string
 	SetScopes([]string)
 
@@ -319,10 +321,6 @@ type RetryableQueue interface {
 	// For retryable jobs, Get will retrieve the latest attempt of a job by ID.
 	Queue
 
-	// GetAttempt returns the job associated with the given attempt of the job
-	// and a bool indicating whether the job was found or not.
-	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)
-
 	// RetryHandler returns the handler for retrying a job in this queue.
 	RetryHandler() RetryHandler
 	// SetRetryHandler permits runtime substitution of RetryHandler
@@ -330,10 +328,19 @@ type RetryableQueue interface {
 	// to change RetryHandler implementations after starting the Queue.
 	SetRetryHandler(RetryHandler) error
 
+	// GetAttempt returns the job associated with the given attempt of the job
+	// and a bool indicating whether the job was found or not.
+	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)
+
+	// kim: TODO: rename to CompleteAndPut
 	// SaveAndPut saves an existing job toSave in the queue (see Save) and
 	// inserts a new job toPut in the queue (see Put). Implementations must
 	// make this operation atomic.
 	SaveAndPut(ctx context.Context, toSave, toPut Job) error
+
+	// CompleteRetry marks a job that needs to retry as finished processing, so
+	// that it will no longer retry.
+	CompleteRetry(ctx context.Context, j RetryableJob) error
 }
 
 // RetryHandler provides a means to retry RetryableJobs within a RetryableQueue.

--- a/interface.go
+++ b/interface.go
@@ -105,6 +105,10 @@ type RetryableJob interface {
 	// AddRetryableError annotates the job with an error and marks the job as
 	// needing to retry.
 	AddRetryableError(error)
+
+	// SetTimeInfo is like UpdateTimeInfo but overwrites all time info,
+	// including zero fields.
+	SetTimeInfo(JobTimeInfo)
 }
 
 // JobType contains information about the type of a job, which queues

--- a/job/base.go
+++ b/job/base.go
@@ -269,6 +269,14 @@ func (b *Base) UpdateTimeInfo(i amboy.JobTimeInfo) {
 	}
 }
 
+// SetTimeInfo sets the value of time in the job, including unset fields.
+func (b *Base) SetTimeInfo(i amboy.JobTimeInfo) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.timeInfo = i
+}
+
 // SetScopes overrides the jobs current scopes with those from the
 // argument. To unset scopes, pass nil to this method.
 func (b *Base) SetScopes(scopes []string) {

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -113,7 +113,7 @@ func (s *BaseCheckSuite) TestDefaultTimeInfoIsUnset() {
 	s.Zero(ti.WaitUntil)
 }
 
-func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
+func (s *BaseCheckSuite) TestUpdateTimeInfoSetsNonzeroValues() {
 	ti := s.base.TimeInfo()
 	ti.Start = time.Now()
 	ti.End = ti.Start.Add(time.Hour)
@@ -142,6 +142,20 @@ func (s *BaseCheckSuite) TestTimeInfoSetsValues() {
 	s.NotEqual(new.End, last.End)
 	s.Equal(result.Start, last.Start)
 	s.Equal(result.End, last.End)
+}
+
+func (s *BaseCheckSuite) TestSetTimeInfoSetsAllValues() {
+	ti := s.base.TimeInfo()
+	ti.Start = time.Now()
+	ti.End = ti.Start.Add(time.Hour)
+	s.Zero(ti.WaitUntil)
+	s.Equal(time.Hour, ti.Duration())
+
+	s.base.SetTimeInfo(ti)
+	s.Equal(ti, s.base.TimeInfo())
+
+	s.base.SetTimeInfo(amboy.JobTimeInfo{})
+	s.Zero(s.base.TimeInfo())
 }
 
 func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -27,10 +27,10 @@ type remoteQueueDriver interface {
 	// Save updates an existing job in the backing storage. Implementations may
 	// not allow calls to Save to run concurrently.
 	Save(context.Context, amboy.Job) error
-	// SaveAndPut performs updates an existing job toSave and inserts a new job
-	// toPut atomically. Implementations may not allow calls to SaveAndPut to
-	// run concurrently.
-	SaveAndPut(ctx context.Context, toSave amboy.Job, toPut amboy.Job) error
+	// CompleteAndPut performs updates an existing job toComplete and inserts a
+	// new job toPut atomically. Implementations may not allow calls to
+	// CompleteAndPut to run concurrently.
+	CompleteAndPut(ctx context.Context, toComplete amboy.Job, toPut amboy.Job) error
 
 	Jobs(context.Context) <-chan amboy.Job
 	Next(context.Context) amboy.Job

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -612,17 +612,6 @@ func (d *mongoDriver) SaveAndPut(ctx context.Context, toSave amboy.Job, toPut am
 	defer sess.EndSession(ctx)
 
 	atomicSaveAndPut := func(sessCtx mongo.SessionContext) (interface{}, error) {
-		// TODO (EVG-13540): for a long-running job that has been lock pinged,
-		// we need to make sure that the modTS/modcount is okay to use. Save()
-		// should still succeed as long as:
-		// * Continuity of in-memory job: the dispatcher shares the same
-		// in-memory copy of the job as the retry handler.
-		// * Concurrency: the dispatcher never runs concurrently with the retry
-		// handler (which would modify modTS/modcount).
-		// * Precondition: the job is complete when this is called.
-		// We should verify these statements are true when doing tests of the
-		// retry handler.
-
 		if err = d.Save(sessCtx, toSave); err != nil {
 			return nil, errors.Wrap(err, "saving old job")
 		}

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -624,7 +624,7 @@ func (d *mongoDriver) CompleteAndPut(ctx context.Context, toComplete amboy.Job, 
 	}
 
 	if _, err = sess.WithTransaction(ctx, atomicCompleteAndPut); err != nil {
-		return errors.Wrap(err, "atomic save and put")
+		return errors.Wrap(err, "atomic complete and put")
 	}
 
 	return nil

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -302,7 +302,7 @@ func (s *DriverSuite) TestPutAndGetRoundTripObjects() {
 	}
 }
 
-func (s *DriverSuite) TestSaveAndPutUpdatesExistingAndAddsNewJob() {
+func (s *DriverSuite) TestCompleteAndPutUpdatesExistingAndAddsNewJob() {
 	j1 := job.NewShellJob("echo foo", "")
 	j2 := job.NewShellJob("echo bar", "")
 
@@ -315,7 +315,7 @@ func (s *DriverSuite) TestSaveAndPutUpdatesExistingAndAddsNewJob() {
 		ModificationCount: 50,
 	})
 
-	s.Require().NoError(s.driver.SaveAndPut(s.ctx, j1, j2))
+	s.Require().NoError(s.driver.CompleteAndPut(s.ctx, j1, j2))
 
 	reloaded1, err := s.driver.Get(s.ctx, j1.ID())
 	s.Require().NoError(err)
@@ -326,7 +326,7 @@ func (s *DriverSuite) TestSaveAndPutUpdatesExistingAndAddsNewJob() {
 	s.Equal(j2.Status().ModificationCount, reloaded2.Status().ModificationCount)
 }
 
-func (s *DriverSuite) TestSaveAndPutIsAtomic() {
+func (s *DriverSuite) TestCompleteAndPutIsAtomic() {
 	j := job.NewShellJob("echo foo", "")
 
 	j.SetStatus(amboy.JobStatusInfo{
@@ -339,14 +339,14 @@ func (s *DriverSuite) TestSaveAndPutIsAtomic() {
 		ModificationCount: 50,
 	})
 
-	s.Require().Error(s.driver.SaveAndPut(s.ctx, j, j))
+	s.Require().Error(s.driver.CompleteAndPut(s.ctx, j, j))
 
 	reloaded, err := s.driver.Get(s.ctx, j.ID())
 	s.Require().NoError(err)
-	s.Equal(5, reloaded.Status().ModificationCount, "SaveAndPut should be atomic")
+	s.Equal(5, reloaded.Status().ModificationCount, "CompleteAndPut should be atomic")
 }
 
-func (s *DriverSuite) TestSaveAndPutAtomicallySwapsScopes() {
+func (s *DriverSuite) TestCompleteAndPutAtomicallySwapsScopes() {
 	j1 := job.NewShellJob("echo foo", "")
 	j2 := job.NewShellJob("echo bar", "")
 
@@ -357,7 +357,7 @@ func (s *DriverSuite) TestSaveAndPutAtomicallySwapsScopes() {
 	j2.SetScopes(j1.Scopes())
 	j1.SetScopes(nil)
 
-	s.Require().NoError(s.driver.SaveAndPut(s.ctx, j1, j2))
+	s.Require().NoError(s.driver.CompleteAndPut(s.ctx, j1, j2))
 
 	reloaded1, err := s.driver.Get(s.ctx, j1.ID())
 	s.Require().NoError(err)

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -36,20 +36,20 @@ type mockRemoteQueue struct {
 	retryHandler amboy.RetryHandler
 
 	// Mockable methods
-	putJob           func(ctx context.Context, q remoteQueue, j amboy.Job) error
-	getJob           func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
-	getJobAttempt    func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.RetryableJob, bool)
-	saveJob          func(ctx context.Context, q remoteQueue, j amboy.Job) error
-	saveAndPutJob    func(ctx context.Context, q remoteQueue, toSave, toPut amboy.Job) error
-	nextJob          func(ctx context.Context, q remoteQueue) amboy.Job
-	completeJob      func(ctx context.Context, q remoteQueue, j amboy.Job)
-	completeJobRetry func(ctx context.Context, q remoteQueue, j amboy.RetryableJob) error
-	jobResults       func(ctx context.Context, q remoteQueue) <-chan amboy.Job
-	jobStats         func(ctx context.Context, q remoteQueue) <-chan amboy.JobStatusInfo
-	queueStats       func(ctx context.Context, q remoteQueue) amboy.QueueStats
-	queueInfo        func(q remoteQueue) amboy.QueueInfo
-	startQueue       func(ctx context.Context, q remoteQueue) error
-	closeQueue       func(ctx context.Context, q remoteQueue)
+	putJob            func(ctx context.Context, q remoteQueue, j amboy.Job) error
+	getJob            func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
+	getJobAttempt     func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.RetryableJob, bool)
+	saveJob           func(ctx context.Context, q remoteQueue, j amboy.Job) error
+	completeAndPutJob func(ctx context.Context, q remoteQueue, toComplete, toPut amboy.Job) error
+	nextJob           func(ctx context.Context, q remoteQueue) amboy.Job
+	completeJob       func(ctx context.Context, q remoteQueue, j amboy.Job)
+	completeJobRetry  func(ctx context.Context, q remoteQueue, j amboy.RetryableJob) error
+	jobResults        func(ctx context.Context, q remoteQueue) <-chan amboy.Job
+	jobStats          func(ctx context.Context, q remoteQueue) <-chan amboy.JobStatusInfo
+	queueStats        func(ctx context.Context, q remoteQueue) amboy.QueueStats
+	queueInfo         func(q remoteQueue) amboy.QueueInfo
+	startQueue        func(ctx context.Context, q remoteQueue) error
+	closeQueue        func(ctx context.Context, q remoteQueue)
 }
 
 type mockRemoteQueueOptions struct {
@@ -149,11 +149,11 @@ func (q *mockRemoteQueue) Save(ctx context.Context, j amboy.Job) error {
 	return q.remoteQueue.Save(ctx, j)
 }
 
-func (q *mockRemoteQueue) SaveAndPut(ctx context.Context, toSave, toPut amboy.Job) error {
-	if q.saveAndPutJob != nil {
-		return q.saveAndPutJob(ctx, q.remoteQueue, toSave, toPut)
+func (q *mockRemoteQueue) CompleteAndPut(ctx context.Context, toComplete, toPut amboy.Job) error {
+	if q.completeAndPutJob != nil {
+		return q.completeAndPutJob(ctx, q.remoteQueue, toComplete, toPut)
 	}
-	return q.remoteQueue.SaveAndPut(ctx, toSave, toPut)
+	return q.remoteQueue.CompleteAndPut(ctx, toComplete, toPut)
 }
 
 func (q *mockRemoteQueue) Next(ctx context.Context) amboy.Job {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1114,6 +1114,7 @@ func ApplyScopesOnEnqueueTest(bctx context.Context, t *testing.T, test QueueTest
 	}
 }
 
+// kim: TODO: add test for scoped job handing off scopes to retry job
 func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
 	ctx, cancel := context.WithTimeout(bctx, time.Minute)
 	defer cancel()

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -277,10 +277,11 @@ func (q *remoteBase) CompleteRetry(ctx context.Context, j amboy.RetryableJob) er
 					j.AddError(catcher.Resolve())
 					return errors.Wrapf(catcher.Resolve(), "giving up after attempt %d", attempt)
 				}
+				timer.Reset(retryInterval)
 				continue
 			}
 
-			timer.Reset(retryInterval)
+			return nil
 		}
 	}
 

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -162,8 +162,8 @@ func (q *remoteBase) Save(ctx context.Context, j amboy.Job) error {
 	return q.driver.Save(ctx, j)
 }
 
-func (q *remoteBase) SaveAndPut(ctx context.Context, toSave, toPut amboy.Job) error {
-	return q.driver.SaveAndPut(ctx, toSave, toPut)
+func (q *remoteBase) CompleteAndPut(ctx context.Context, toComplete, toPut amboy.Job) error {
+	return q.driver.CompleteAndPut(ctx, toComplete, toPut)
 }
 
 // Complete takes a context and, asynchronously, marks the job

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -273,10 +273,11 @@ func (q *remoteBase) CompleteRetry(ctx context.Context, j amboy.RetryableJob) er
 
 			if err := q.driver.Complete(ctx, j); err != nil {
 				catcher.Wrapf(err, "attempt %d", attempt)
-				if attempt >= 10 || isMongoDupKey(err) {
+				if isMongoDupKey(err) {
 					j.AddError(catcher.Resolve())
 					return errors.Wrapf(catcher.Resolve(), "giving up after attempt %d", attempt)
 				}
+
 				timer.Reset(retryInterval)
 				continue
 			}

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -144,8 +144,6 @@ func (rh *basicRetryHandler) waitForJob(ctx context.Context) error {
 					}
 				}
 			}()
-			// TODO (EVG-13540): make this use a channel instead checking in a
-			// no-op loop.
 			j = rh.nextJob()
 			if j == nil {
 				timer.Reset(rh.opts.WorkerCheckInterval)
@@ -239,7 +237,6 @@ func (rh *basicRetryHandler) handleJob(ctx context.Context, j amboy.RetryableJob
 		case <-timer.C:
 			if err := rh.tryEnqueueJob(ctx, j); err != nil {
 				catcher.Wrapf(err, "enqueue retry job attempt %d", i)
-				// TODO (EVG-13540): consider adding jitter.
 				timer.Reset(rh.opts.RetryBackoff)
 				continue
 			}

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -156,6 +156,8 @@ func (rh *basicRetryHandler) waitForJob(ctx context.Context) error {
 				}))
 				j.AddError(err)
 
+				// Since the job could not retry successfully, do not let the
+				// job retry again.
 				if err := rh.queue.CompleteRetry(ctx, j); err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"message":  "failed to mark job retry as processed",

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -186,7 +186,7 @@ func (rh *basicRetryHandler) handleJob(ctx context.Context, j amboy.RetryableJob
 	catcher := grip.NewBasicCatcher()
 	timer := time.NewTimer(0)
 	defer timer.Stop()
-	for i := 0; i < rh.opts.MaxRetryAttempts; i++ {
+	for i := 1; i <= rh.opts.MaxRetryAttempts; i++ {
 		if time.Since(startAt) > rh.opts.MaxRetryTime {
 			return errors.Errorf("giving up after %d attempts, %f seconds due to maximum retry time", i, rh.opts.MaxRetryTime.Seconds())
 		}

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -246,7 +246,7 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		oldInfo.NeedsRetry = false
 		j.UpdateRetryInfo(oldInfo.Options())
 
-		err := rh.queue.SaveAndPut(ctx, j, newJob)
+		err := rh.queue.CompleteAndPut(ctx, j, newJob)
 		if amboy.IsDuplicateJobError(err) {
 			// The new job is already in the queue, do nothing.
 			return nil

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -242,6 +242,7 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		newInfo.CurrentAttempt++
 		newJob.UpdateRetryInfo(newInfo.Options())
 		newJob.SetStatus(amboy.JobStatusInfo{})
+		newJob.SetTimeInfo(amboy.JobTimeInfo{})
 
 		oldInfo.NeedsRetry = false
 		j.UpdateRetryInfo(oldInfo.Options())

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -213,7 +213,6 @@ func (rh *basicRetryHandler) handleJob(ctx context.Context, j amboy.RetryableJob
 
 func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.RetryableJob) error {
 	originalInfo := j.RetryInfo()
-	originalScopes := j.Scopes()
 
 	err := func() error {
 		oldInfo := j.RetryInfo()
@@ -261,7 +260,6 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 	if err != nil {
 		// Restore the original retry information if it failed to re-enqueue.
 		j.UpdateRetryInfo(originalInfo.Options())
-		j.SetScopes(originalScopes)
 	}
 
 	return err

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -253,7 +253,7 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		oldInfo.NeedsRetry = false
 		j.UpdateRetryInfo(oldInfo.Options())
 
-		err := rh.queue.CompleteAndPut(ctx, j, newJob)
+		err = rh.queue.CompleteAndPut(ctx, j, newJob)
 		if amboy.IsDuplicateJobError(err) {
 			// The new job is already in the queue, do nothing.
 			return false, err

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -168,7 +168,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 
 					assert.True(t, calledGetAttempt)
-					assert.True(t, calledCompleteRetry)
+					assert.False(t, calledCompleteRetry)
 					assert.True(t, calledCompleteAndPut)
 				},
 				"PutSucceedsButDoesNothingIfUnstarted": func(ctx context.Context, t *testing.T, makeQueueAndRetryHandler func(opts amboy.RetryHandlerOptions) (*mockRemoteQueue, amboy.RetryHandler, error)) {

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -152,6 +152,10 @@ func (j *JobTest) UpdateTimeInfo(i amboy.JobTimeInfo) {
 	j.TimingInfo = i
 }
 
+func (j *JobTest) SetTimeInfo(i amboy.JobTimeInfo) {
+	j.TimingInfo = i
+}
+
 func (j *JobTest) SetScopes(in []string) {
 	j.LockScopes = in
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13540
Patch: https://evergreen.mongodb.com/version/602fe3331e2d171e697ea37a

* Add configurable wait interval between checking for new jobs.
* Safely unset the scopes the old job was holding onto in the retry handler and change the method to `CompleteAndPut()`. This is to handle the case in which the old job is trying to atomically hand the scopes to the new job. The job has to hold them until the retry handler finishes processing the job, after which point it should release the scopes.
* Try multiple times to mark the job as processed using `CompleteRetry()`. [EVG-13784](https://jira.mongodb.org/browse/EVG-13784) will deal with the edge case of  it failing to save the job by ensuring the job does eventually unset NeedsRetry and its scopes (e.g. most likely, either the context errored or the job document was changed so that the in-memory copy is outdated). That ticket will ensure the job does not just retry infinitely and does not hold its scopes forever.