### PR TITLE
EVG-13591: add error type for duplicate scopes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,8 +7,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EnqueueUniqueJob is a generic wrapper for adding jobs to queues
-// (using the Put() method), but that ignores duplicate job errors.
+// EnqueueUniqueJob is a generic wrapper for adding jobs to queues (using the
+// Put() method), but that ignores duplicate job errors.
 func EnqueueUniqueJob(ctx context.Context, queue Queue, job Job) error {
 	err := queue.Put(ctx, job)
 
@@ -48,12 +48,53 @@ func MakeDuplicateJobError(err error) error {
 
 // IsDuplicateJobError tests an error object to see if it is a
 // duplicate job error.
-// TODO (EVG-13591): handle duplicate scope errors properly.
 func IsDuplicateJobError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	_, ok := errors.Cause(err).(*duplJobError)
+	switch errors.Cause(err).(type) {
+	case *duplJobError, *duplJobScopeError:
+		return true
+	default:
+		return false
+	}
+}
+
+type duplJobScopeError struct {
+	*duplJobError
+}
+
+// NewDuplicateJobScopeError creates a new error object to represent a duplicate
+// job scope error, for use by queue implementations.
+func NewDuplicateJobScopeError(msg string) error {
+	return &duplJobScopeError{duplJobError: &duplJobError{msg: msg}}
+}
+
+// NewDuplicateJobScopeErrorf creates a new error object to represent a
+// duplicate job scope error with a formatted message, for use by queue
+// implementations.
+func NewDuplicateJobScopeErrorf(msg string, args ...interface{}) error {
+	return NewDuplicateJobScopeError(fmt.Sprintf(msg, args...))
+}
+
+// MakeDuplicateJobScopeError constructs a duplicate job scope error from an
+// existing error of any type, for use by queue implementations.
+func MakeDuplicateJobScopeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return NewDuplicateJobScopeError(err.Error())
+}
+
+// IsDuplicateJobScopeError tests an error object to see if it is a duplicate
+// job scope error.
+func IsDuplicateJobScopeError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := errors.Cause(err).(*duplJobScopeError)
 	return ok
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,14 +8,43 @@ import (
 )
 
 func TestDuplicateError(t *testing.T) {
-	assert.False(t, IsDuplicateJobError(errors.New("err")))
-	assert.False(t, IsDuplicateJobError(nil))
-	assert.True(t, IsDuplicateJobError(NewDuplicateJobError("err")))
-	assert.True(t, IsDuplicateJobError(NewDuplicateJobErrorf("err")))
-	assert.True(t, IsDuplicateJobError(NewDuplicateJobErrorf("err %s", "err")))
-	assert.True(t, IsDuplicateJobError(MakeDuplicateJobError(errors.New("err"))))
-
-	assert.True(t, IsDuplicateJobError(NewDuplicateJobScopeError("err")))
-	// err := NewDuplicateJobError("scope error")
-	// assert.True(t, IsDuplicateJobError(err))
+	t.Run("RegularErrorIsNotDuplicate", func(t *testing.T) {
+		err := errors.New("err")
+		assert.False(t, IsDuplicateJobError(err))
+		assert.False(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("NilErrorIsNotDuplicate", func(t *testing.T) {
+		assert.False(t, IsDuplicateJobError(nil))
+		assert.False(t, IsDuplicateJobScopeError(nil))
+	})
+	t.Run("NewDuplicateJobError", func(t *testing.T) {
+		err := NewDuplicateJobError("err")
+		assert.True(t, IsDuplicateJobError(err))
+		assert.False(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("NewDuplicateJobErrorf", func(t *testing.T) {
+		err := NewDuplicateJobErrorf("err %s", "err")
+		assert.True(t, IsDuplicateJobError(err))
+		assert.False(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("MakeDuplicateJobError", func(t *testing.T) {
+		err := MakeDuplicateJobError(errors.New("err"))
+		assert.True(t, IsDuplicateJobError(err))
+		assert.False(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("NewDuplicateJobScopeError", func(t *testing.T) {
+		err := NewDuplicateJobScopeError("err")
+		assert.True(t, IsDuplicateJobError(err))
+		assert.True(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("NewDuplicateScopeJobErrorf", func(t *testing.T) {
+		err := NewDuplicateJobScopeErrorf("err %s", "err")
+		assert.True(t, IsDuplicateJobError(err))
+		assert.True(t, IsDuplicateJobScopeError(err))
+	})
+	t.Run("MakeDuplicateScopeJobError", func(t *testing.T) {
+		err := MakeDuplicateJobScopeError(errors.New("err"))
+		assert.True(t, IsDuplicateJobError(err))
+		assert.True(t, IsDuplicateJobScopeError(err))
+	})
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -14,4 +14,8 @@ func TestDuplicateError(t *testing.T) {
 	assert.True(t, IsDuplicateJobError(NewDuplicateJobErrorf("err")))
 	assert.True(t, IsDuplicateJobError(NewDuplicateJobErrorf("err %s", "err")))
 	assert.True(t, IsDuplicateJobError(MakeDuplicateJobError(errors.New("err"))))
+
+	assert.True(t, IsDuplicateJobError(NewDuplicateJobScopeError("err")))
+	// err := NewDuplicateJobError("scope error")
+	// assert.True(t, IsDuplicateJobError(err))
 }

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -624,6 +624,9 @@ func getMongoDupKeyErrors(err error) mongoDupKeyErrors {
 	return dupKeyErrs
 }
 
+// TODO: this logic is a copy-paste and could potentially be replaced by
+// upgrading the Go driver to a newer version:
+// (https://github.com/mongodb/mongo-go-driver/blob/213fb80b373f70dba4f9f516dc4c718abe41c76b/mongo/errors.go#L87-L96)
 func getMongoDupKeyWriteConcernError(err mongo.WriteException) *mongo.WriteConcernError {
 	wce := err.WriteConcernError
 	if wce == nil {

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -368,6 +368,10 @@ func (s *DriverSuite) TestCompleteAndPutAtomicallySwapsScopes() {
 	s.Equal(j2.Scopes(), reloaded2.Scopes())
 }
 
+// kim: TODO: test:
+// - Put fails due to duplicate scope error (need unique index).
+// - SaveAndPut fails due to duplicate job ID error.
+
 func (s *DriverSuite) TestReloadRefreshesJobFromMemory() {
 	j := job.NewShellJob("echo foo", "")
 

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -396,8 +396,8 @@ func (s *DriverSuite) TestCompleteAndPutJobsFailsWithDuplicateJobID() {
 
 	err := s.driver.CompleteAndPut(s.ctx, j1, j2)
 	s.Require().Error(err)
-	s.True(amboy.IsDuplicateJobError(err))
-	s.False(amboy.IsDuplicateJobScopeError(err))
+	s.True(amboy.IsDuplicateJobError(err), "error: %v", err)
+	s.False(amboy.IsDuplicateJobScopeError(err), "error: %v", err)
 }
 
 func (s *DriverSuite) TestCompleteAndPutJobsSucceedsWithDuplicateScopes() {
@@ -433,8 +433,8 @@ func (s *DriverSuite) TestCompleteAndPutJobsFailsWithDuplicateJobScopesAppliedOn
 
 	err := s.driver.CompleteAndPut(s.ctx, j1, j2)
 	s.Require().Error(err)
-	s.True(amboy.IsDuplicateJobError(err))
-	s.True(amboy.IsDuplicateJobScopeError(err))
+	s.True(amboy.IsDuplicateJobError(err), "error: %v", err)
+	s.True(amboy.IsDuplicateJobScopeError(err), "error: %v", err)
 }
 
 func (s *DriverSuite) TestReloadRefreshesJobFromMemory() {

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -257,16 +257,6 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 
 		err = rh.queue.CompleteAndPut(ctx, j, newJob)
 		if amboy.IsDuplicateJobError(err) {
-			// Either:
-			// - The new job is already in the queue, so do nothing.
-			// - The new job cannot acquire its scopes, because another job is
-			//   currently holding the scope its trying to acquire. It cannot be
-			//   held by the job currently attempting to retry, because that job
-			//   should drop its scopes before the new job attempts to acquire
-			//   them. There's nothing we can do in this case, so give up now.
-			//   The only way this could occur would be if the job's scopes to
-			//   acquire were modified after the job was enqueued, which is an
-			//   invalid use of scopes.
 			return false, err
 		} else if err != nil {
 			return true, errors.Wrap(err, "enqueueing retry job")

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -257,7 +257,16 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 
 		err = rh.queue.CompleteAndPut(ctx, j, newJob)
 		if amboy.IsDuplicateJobError(err) {
-			// The new job is already in the queue, do nothing.
+			// Either:
+			// - The new job is already in the queue, so do nothing.
+			// - The new job cannot acquire its scopes, because another job is
+			//   currently holding the scope its trying to acquire. It cannot be
+			//   held by the job currently attempting to retry, because that job
+			//   should drop its scopes before the new job attempts to acquire
+			//   them. There's nothing we can do in this case, so give up now.
+			//   The only way this could occur would be if the job's scopes to
+			//   acquire were modified after the job was enqueued, which is an
+			//   invalid use of scopes.
 			return false, err
 		} else if err != nil {
 			return true, errors.Wrap(err, "enqueueing retry job")

--- a/queue/scope.go
+++ b/queue/scope.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"sync"
 
+	"github.com/mongodb/amboy"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func (s *scopeManagerImpl) Acquire(id string, scopes []string) error {
 		if holder == id {
 			continue
 		}
-		return errors.Errorf("could not acquire lock scope '%s' held by '%s' not '%s'", sc, holder, id)
+		return amboy.NewDuplicateJobScopeErrorf("could not acquire lock scope '%s' held by '%s' not '%s'", sc, holder, id)
 	}
 
 	for _, sc := range scopesToAcquire {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13591
Patch: https://evergreen.mongodb.com/version/603437170305b916143db426

* Add a new error type, which is a type of duplicate key error, specifically for handling duplicate key errors due to another job holding the scope. For `amboy.EnqueueUniqueJob()`, it'll still squash errors due to acquiring duplicate scopes. If you want to check specifically for the duplicate scope case, you can just due `(amboy.Queue).Put()` and check for the duplicate key or scope error. The check is kind of fragile since it depends on parsing the error message text, but it seems like the server doesn't provide a nicer way to determine the index that caused the write failure.
* Return duplicate job scope errors if insertion fails because of the uniqueness constraint of scopes.