### PR TITLE
EVG-13544: add option for max job attempts

### DIFF
--- a/job/base.go
+++ b/job/base.go
@@ -345,4 +345,7 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.CurrentAttempt != nil {
 		b.retryInfo.CurrentAttempt = *opts.CurrentAttempt
 	}
+	if opts.MaxAttempts != nil {
+		b.retryInfo.MaxAttempts = *opts.MaxAttempts
+	}
 }

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -166,29 +166,33 @@ func (s *BaseCheckSuite) TestUpdateRetryInfoSetsNonzeroFields() {
 		Retryable: true,
 	}, s.base.RetryInfo())
 
-	trial := 5
+	attempt := 5
+	maxAttempt := 10
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
-		CurrentAttempt: utility.ToIntPtr(trial),
+		CurrentAttempt: utility.ToIntPtr(attempt),
+		MaxAttempts:    utility.ToIntPtr(maxAttempt),
 	})
-
 	s.Require().Equal(amboy.JobRetryInfo{
 		Retryable:      true,
-		CurrentAttempt: trial,
+		CurrentAttempt: attempt,
+		MaxAttempts:    maxAttempt,
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable: utility.FalsePtr(),
 	})
 	s.Require().Equal(amboy.JobRetryInfo{
-		CurrentAttempt: trial,
+		Retryable:      false,
+		CurrentAttempt: attempt,
+		MaxAttempts:    maxAttempt,
 	}, s.base.RetryInfo())
 
 	s.base.UpdateRetryInfo(amboy.JobRetryOptions{
 		NeedsRetry: utility.TruePtr(),
 	})
-
 	s.Require().Equal(amboy.JobRetryInfo{
 		NeedsRetry:     true,
-		CurrentAttempt: trial,
+		CurrentAttempt: attempt,
+		MaxAttempts:    maxAttempt,
 	}, s.base.RetryInfo())
 }

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -237,6 +237,9 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		if !newInfo.Retryable || !newInfo.NeedsRetry {
 			return false, errors.New("job in the queue indicates the job does not need to retry anymore")
 		}
+		if oldInfo.CurrentAttempt+1 > newInfo.GetMaxAttempts() {
+			return false, errors.New("job has exceeded its maximum attempt limit")
+		}
 
 		// TODO (EVG-13584): add job retry locking mechanism (similar to
 		// (amboy.Job).Lock()) to ensure that this thread on this host has sole


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13544
Patch: https://evergreen.mongodb.com/version/60341d202a60ed7e784ec73f

Add job option to put an upper limit on the number of times it will retry.