### PR TITLE
EVG-13784: monitor stale retrying jobs

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -191,6 +191,8 @@ func (info *JobRetryInfo) Options() JobRetryOptions {
 
 const defaultRetryableMaxAttempts = 10
 
+// GetMaxAttempts returns the maximum number of times a job is allowed to
+// attempt. It defaults the maximum attempts if it's unset.
 func (info *JobRetryInfo) GetMaxAttempts() int {
 	if info.MaxAttempts <= 0 {
 		return defaultRetryableMaxAttempts
@@ -400,6 +402,7 @@ type RetryHandlerOptions struct {
 	WorkerCheckInterval time.Duration
 }
 
+// Validate checks that all retry handler options are valid.
 func (opts *RetryHandlerOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(opts.MaxRetryAttempts < 0, "cannot have negative max retry attempts")

--- a/job/base.go
+++ b/job/base.go
@@ -132,6 +132,9 @@ func (b *Base) Lock(id string, lockTimeout time.Duration) error {
 		return errors.Errorf("cannot take lock for '%s' because lock has been held for %s by %s",
 			id, time.Since(b.status.ModificationTime), b.status.Owner)
 	}
+	if b.status.Completed && b.retryInfo.NeedsRetry && time.Since(b.status.ModificationTime) < lockTimeout && b.status.Owner != id {
+		return errors.Errorf("cannot take retry lock for '%s' because lock has been held for %s by %s", id, time.Since(b.status.ModificationTime), b.status.Owner)
+	}
 	b.status.InProgress = true
 	b.status.Owner = id
 	b.status.ModificationTime = time.Now()

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -641,29 +641,6 @@ func (d *mongoDriver) Complete(ctx context.Context, j amboy.Job) error {
 	// job, we cannot let go of the scopes yet because they will need to be
 	// safely transferred to the retry job.
 	if !ji.RetryInfo.Retryable || !ji.RetryInfo.NeedsRetry || !ji.ApplyScopesOnEnqueue {
-		// kim: NOTE: retryable errors are implicitly handled here simply by
-		// updating NeedsRetry.
-		// If a retryable error is added:
-		//  - Complete succeeds and sets NeedsRetry = true. The retry handler will
-		//    handle it eventually since NeedsRetry is persisted.
-		//  - Complete fails and fails to set NeedsRetry, but Amboy will restart
-		//    stuck in progress jobs.
-		// If no retryable error is added:
-		//	- Complete succeeds and job does not need to retry, so it sets
-		//	  NeedsRetry = false. The retry handler will ignore the job.
-		//  - Complete fails and Amboy's policy is to restart stuck in progress
-		//    jobs.
-		// The only problem case would be when Retryable/NeedsRetry are both true
-		// in-memory but someone unsets them manually in the DB. In that case, the
-		// retry handler will retry the job even though someone manually set it to
-		// not run.
-		// It might be complicated, but one potential way to do it would be to check
-		// Retryable and only update the RetryInfo if Retryable if still true when
-		// Complete occurs.
-		// Another way would be for someone to also reset the modcount to 0 when
-		// they unset the retryable options (which will cause the pinger to abort
-		// and also cause the complete save to fail). As long as they mark the job
-		// complete, it should be fine and it won't magically restart again.
 		ji.Scopes = nil
 	}
 

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -641,6 +641,29 @@ func (d *mongoDriver) Complete(ctx context.Context, j amboy.Job) error {
 	// job, we cannot let go of the scopes yet because they will need to be
 	// safely transferred to the retry job.
 	if !ji.RetryInfo.Retryable || !ji.RetryInfo.NeedsRetry || !ji.ApplyScopesOnEnqueue {
+		// kim: NOTE: retryable errors are implicitly handled here simply by
+		// updating NeedsRetry.
+		// If a retryable error is added:
+		//  - Complete succeeds and sets NeedsRetry = true. The retry handler will
+		//    handle it eventually since NeedsRetry is persisted.
+		//  - Complete fails and fails to set NeedsRetry, but Amboy will restart
+		//    stuck in progress jobs.
+		// If no retryable error is added:
+		//	- Complete succeeds and job does not need to retry, so it sets
+		//	  NeedsRetry = false. The retry handler will ignore the job.
+		//  - Complete fails and Amboy's policy is to restart stuck in progress
+		//    jobs.
+		// The only problem case would be when Retryable/NeedsRetry are both true
+		// in-memory but someone unsets them manually in the DB. In that case, the
+		// retry handler will retry the job even though someone manually set it to
+		// not run.
+		// It might be complicated, but one potential way to do it would be to check
+		// Retryable and only update the RetryInfo if Retryable if still true when
+		// Complete occurs.
+		// Another way would be for someone to also reset the modcount to 0 when
+		// they unset the retryable options (which will cause the pinger to abort
+		// and also cause the complete save to fail). As long as they mark the job
+		// complete, it should be fine and it won't magically restart again.
 		ji.Scopes = nil
 	}
 

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -469,9 +469,9 @@ func (q *remoteBase) lockDispatch(j amboy.Job) bool {
 
 func (q *remoteBase) monitorStaleRetryingJobs(ctx context.Context) {
 	defer func() {
-		if err := recovery.HandlePanicWithError(recover(), nil, "retry handler stuck retry job monitor"); err != nil {
+		if err := recovery.HandlePanicWithError(recover(), nil, "stale retry job monitor"); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"message":  "stuck retry job monitor failed",
+				"message":  "stale retry job monitor failed",
 				"service":  "amboy.queue.mdb",
 				"queue_id": q.ID(),
 			}))

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
 
@@ -414,6 +415,7 @@ func (q *remoteBase) Start(ctx context.Context) error {
 		if err = q.retryHandler.Start(ctx); err != nil {
 			return errors.Wrap(err, "starting retry handler in remote queue")
 		}
+		go q.monitorStaleRetryingJobs(ctx)
 	}
 
 	go q.jobServer(ctx)
@@ -465,20 +467,35 @@ func (q *remoteBase) lockDispatch(j amboy.Job) bool {
 	return true
 }
 
-func isDispatchable(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
-	if jobCanRestart(stat, lockTimeout) {
-		return true
-	}
-	if stat.Completed {
-		return false
-	}
-	if stat.InProgress {
-		return false
-	}
+func (q *remoteBase) monitorStaleRetryingJobs(ctx context.Context) {
+	defer func() {
+		if err := recovery.HandlePanicWithError(recover(), nil, "retry handler stuck retry job monitor"); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":  "stuck retry job monitor failed",
+				"service":  "amboy.queue.mdb",
+				"queue_id": q.ID(),
+			}))
+			go q.monitorStaleRetryingJobs(ctx)
+		}
+	}()
 
-	return true
-}
-
-func jobCanRestart(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
-	return stat.InProgress && time.Since(stat.ModificationTime) > lockTimeout
+	const monitorInterval = time.Second
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			for j := range q.driver.RetryableJobs(ctx, RetryableJobStaleRetrying) {
+				grip.Error(message.WrapError(q.retryHandler.Put(ctx, j), message.Fields{
+					"message":  "could not enqueue stale retrying job",
+					"service":  "amboy.queue.mdb",
+					"job_id":   j.ID(),
+					"queue_id": q.ID(),
+				}))
+			}
+			timer.Reset(monitorInterval)
+		}
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13784

* Add a goroutine to monitor for job that are in the process of retrying but are not actively marked as retrying (i.e. the lock timeout is exceeded).
    * Add a driver method to return retryable jobs based on a filter.
* Atomically lock a retry job to a single in-memory queue's retry handler.
* Move a few random helper functions to more appropriate places.