### PR TITLE
EVG-13541, EVG-13542: add options for DispatchBy and WaitFor

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -366,15 +366,14 @@ type RetryableQueue interface {
 	// and a bool indicating whether the job was found or not.
 	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)
 
-	// CompleteAndPut marks an existing job toComplete in the queue (see
-	// CompleteRetry) as finished processing its retry and inserts a new job
-	// toPut in the queue (see Put). Implementations must make this operation
-	// atomic.
-	CompleteAndPut(ctx context.Context, toComplete, toPut Job) error
+	// CompleteRetryingAndPut marks an existing job toComplete in the queue (see
+	// CompleteRetrying) as finished retrying and inserts a new job toPut in the
+	// queue (see Put). Implementations must make this operation atomic.
+	CompleteRetryingAndPut(ctx context.Context, toComplete, toPut RetryableJob) error
 
-	// CompleteRetry marks a job that needs to retry as finished processing, so
+	// CompleteRetrying marks a job that is retrying as finished processing, so
 	// that it will no longer retry.
-	CompleteRetry(ctx context.Context, j RetryableJob) error
+	CompleteRetrying(ctx context.Context, j RetryableJob) error
 }
 
 // RetryHandler provides a means to retry RetryableJobs within a RetryableQueue.

--- a/interface.go
+++ b/interface.go
@@ -122,7 +122,7 @@ type JobType struct {
 
 // JobStatusInfo contains information about the current status of a
 // job and is reported by the Status and set by the SetStatus methods
-// in the Job interface.e
+// in the Job interface.
 type JobStatusInfo struct {
 	ID                string    `bson:"id,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
 	Owner             string    `bson:"owner" json:"owner" yaml:"owner"`
@@ -175,6 +175,16 @@ type JobRetryInfo struct {
 	// will be allowed to run 3 times at most. If unset, the default maximum
 	// attempts is 10.
 	MaxAttempts int `bson:"max_attempts,omitempty" json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	// DispatchBy reflects the amount of time (relative to when the job is
+	// retried) that the retried job has to dispatch for execution. If this
+	// deadline elapses, the job will not run. This is analogous to
+	// (JobTimeInfo).DispatchBy.
+	DispatchBy time.Duration `bson:"dispatch_by,omitempty" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
+	// WaitUntil reflects the amount of time (relative to when the job is
+	// retried) that the retried job has to wait before it can be dispatched for
+	// execution. The job will not run until this waiting period elapses. This
+	// is analogous to (JobTimeInfo).WaitUntil.
+	WaitUntil time.Duration `bson:"wait_until,omitempty" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
 }
 
 // Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other
@@ -186,6 +196,8 @@ func (info *JobRetryInfo) Options() JobRetryOptions {
 		NeedsRetry:     &info.NeedsRetry,
 		CurrentAttempt: &info.CurrentAttempt,
 		MaxAttempts:    &info.MaxAttempts,
+		DispatchBy:     &info.DispatchBy,
+		WaitUntil:      &info.WaitUntil,
 	}
 }
 
@@ -202,10 +214,12 @@ func (info *JobRetryInfo) GetMaxAttempts() int {
 // Their meaning corresponds to the fields in JobRetryInfo, but is more amenable
 // to optional input values.
 type JobRetryOptions struct {
-	Retryable      *bool `bson:"-" json:"-" yaml:"-"`
-	NeedsRetry     *bool `bson:"-" json:"-" yaml:"-"`
-	CurrentAttempt *int  `bson:"-" json:"-" yaml:"-"`
-	MaxAttempts    *int  `bson:"-" json:"-" yaml:"-"`
+	Retryable      *bool          `bson:"-" json:"-" yaml:"-"`
+	NeedsRetry     *bool          `bson:"-" json:"-" yaml:"-"`
+	CurrentAttempt *int           `bson:"-" json:"-" yaml:"-"`
+	MaxAttempts    *int           `bson:"-" json:"-" yaml:"-"`
+	DispatchBy     *time.Duration `bson:"-" json:"-" yaml:"-"`
+	WaitUntil      *time.Duration `bson:"-" json:"-" yaml:"-"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/job/base.go
+++ b/job/base.go
@@ -348,4 +348,10 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.MaxAttempts != nil {
 		b.retryInfo.MaxAttempts = *opts.MaxAttempts
 	}
+	if opts.DispatchBy != nil {
+		b.retryInfo.DispatchBy = *opts.DispatchBy
+	}
+	if opts.WaitUntil != nil {
+		b.retryInfo.WaitUntil = *opts.WaitUntil
+	}
 }

--- a/queue/adaptive_order_storage_test.go
+++ b/queue/adaptive_order_storage_test.go
@@ -113,7 +113,7 @@ func (s *AdaptiveOrderItemsSuite) TestRefilterIgnoresWorkWithCanceledContext() {
 	s.Len(s.items.stalled, 1)
 }
 
-func (s *AdaptiveOrderItemsSuite) TestRefilterReoRdersItemsInSuite() {
+func (s *AdaptiveOrderItemsSuite) TestRefilterReordersItemsInSuite() {
 	ctx := context.Background()
 	originalOrder := []string{"foo", "bar", "buzz", "what", "foo"}
 	s.items.ready = []string{"foo", "bar", "buzz", "what", "foo"}

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -36,20 +36,20 @@ type mockRemoteQueue struct {
 	retryHandler amboy.RetryHandler
 
 	// Mockable methods
-	putJob            func(ctx context.Context, q remoteQueue, j amboy.Job) error
-	getJob            func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
-	getJobAttempt     func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.RetryableJob, bool)
-	saveJob           func(ctx context.Context, q remoteQueue, j amboy.Job) error
-	completeAndPutJob func(ctx context.Context, q remoteQueue, toComplete, toPut amboy.Job) error
-	nextJob           func(ctx context.Context, q remoteQueue) amboy.Job
-	completeJob       func(ctx context.Context, q remoteQueue, j amboy.Job)
-	completeJobRetry  func(ctx context.Context, q remoteQueue, j amboy.RetryableJob) error
-	jobResults        func(ctx context.Context, q remoteQueue) <-chan amboy.Job
-	jobStats          func(ctx context.Context, q remoteQueue) <-chan amboy.JobStatusInfo
-	queueStats        func(ctx context.Context, q remoteQueue) amboy.QueueStats
-	queueInfo         func(q remoteQueue) amboy.QueueInfo
-	startQueue        func(ctx context.Context, q remoteQueue) error
-	closeQueue        func(ctx context.Context, q remoteQueue)
+	putJob                    func(ctx context.Context, q remoteQueue, j amboy.Job) error
+	getJob                    func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
+	getJobAttempt             func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.RetryableJob, bool)
+	saveJob                   func(ctx context.Context, q remoteQueue, j amboy.Job) error
+	completeRetryingAndPutJob func(ctx context.Context, q remoteQueue, toComplete, toPut amboy.RetryableJob) error
+	nextJob                   func(ctx context.Context, q remoteQueue) amboy.Job
+	completeJob               func(ctx context.Context, q remoteQueue, j amboy.Job)
+	completeRetryingJob       func(ctx context.Context, q remoteQueue, j amboy.RetryableJob) error
+	jobResults                func(ctx context.Context, q remoteQueue) <-chan amboy.Job
+	jobStats                  func(ctx context.Context, q remoteQueue) <-chan amboy.JobStatusInfo
+	queueStats                func(ctx context.Context, q remoteQueue) amboy.QueueStats
+	queueInfo                 func(q remoteQueue) amboy.QueueInfo
+	startQueue                func(ctx context.Context, q remoteQueue) error
+	closeQueue                func(ctx context.Context, q remoteQueue)
 }
 
 type mockRemoteQueueOptions struct {
@@ -149,11 +149,11 @@ func (q *mockRemoteQueue) Save(ctx context.Context, j amboy.Job) error {
 	return q.remoteQueue.Save(ctx, j)
 }
 
-func (q *mockRemoteQueue) CompleteAndPut(ctx context.Context, toComplete, toPut amboy.Job) error {
-	if q.completeAndPutJob != nil {
-		return q.completeAndPutJob(ctx, q.remoteQueue, toComplete, toPut)
+func (q *mockRemoteQueue) CompleteRetryingAndPut(ctx context.Context, toComplete, toPut amboy.RetryableJob) error {
+	if q.completeRetryingAndPutJob != nil {
+		return q.completeRetryingAndPutJob(ctx, q.remoteQueue, toComplete, toPut)
 	}
-	return q.remoteQueue.CompleteAndPut(ctx, toComplete, toPut)
+	return q.remoteQueue.CompleteRetryingAndPut(ctx, toComplete, toPut)
 }
 
 func (q *mockRemoteQueue) Next(ctx context.Context) amboy.Job {
@@ -171,11 +171,11 @@ func (q *mockRemoteQueue) Complete(ctx context.Context, j amboy.Job) {
 	q.remoteQueue.Complete(ctx, j)
 }
 
-func (q *mockRemoteQueue) CompleteRetry(ctx context.Context, j amboy.RetryableJob) error {
-	if q.completeJobRetry != nil {
-		return q.completeJobRetry(ctx, q.remoteQueue, j)
+func (q *mockRemoteQueue) CompleteRetrying(ctx context.Context, j amboy.RetryableJob) error {
+	if q.completeRetryingJob != nil {
+		return q.completeRetryingJob(ctx, q.remoteQueue, j)
 	}
-	return q.remoteQueue.CompleteRetry(ctx, j)
+	return q.remoteQueue.CompleteRetrying(ctx, j)
 }
 
 func (q *mockRemoteQueue) Results(ctx context.Context) <-chan amboy.Job {

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -251,9 +251,25 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 
 		newInfo.NeedsRetry = false
 		newInfo.CurrentAttempt++
+		var dispatchBy time.Time
+		if newInfo.DispatchBy != 0 {
+			dispatchBy = time.Now().Add(newInfo.DispatchBy)
+		} else {
+			dispatchBy = newJob.TimeInfo().DispatchBy
+		}
+		var waitUntil time.Time
+		if newInfo.WaitUntil != 0 {
+			waitUntil = time.Now().Add(newInfo.WaitUntil)
+		} else {
+			waitUntil = newJob.TimeInfo().WaitUntil
+		}
+		newJob.SetTimeInfo(amboy.JobTimeInfo{
+			DispatchBy: dispatchBy,
+			WaitUntil:  waitUntil,
+			MaxTime:    newJob.TimeInfo().MaxTime,
+		})
 		newJob.UpdateRetryInfo(newInfo.Options())
 		newJob.SetStatus(amboy.JobStatusInfo{})
-		newJob.SetTimeInfo(amboy.JobTimeInfo{})
 
 		oldInfo.NeedsRetry = false
 		j.UpdateRetryInfo(oldInfo.Options())


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13541
https://jira.mongodb.org/browse/EVG-13542
Patch: https://evergreen.mongodb.com/version/60366e44a4cf47157e163468

* Add settings to modify DispatchBy and WaitFor on retried jobs.
* Rename functions (i.e. CompleteRetry -> CompleteRetrying and CompleteAndPut -> CompleteRetryingAndPut) to make it more explicit that this is marking a retrying job as processed (instead of marking a regular job as completed executing).
* Push job metadata updates into the queue level to be consistent with guarantees on other queue methods (e.g. Put must set the job creation time).