### PR TITLE
EVG-13784: add retry handler and remote queue integration tests

### DIFF
--- a/benchmarks/harness.go
+++ b/benchmarks/harness.go
@@ -166,7 +166,7 @@ func queueBenchmarkSuite() poplar.BenchmarkSuite {
 
 func makeMongoDBQueue(ctx context.Context) (amboy.Queue, closeFunc, error) {
 	mdbOpts := queue.DefaultMongoDBOptions()
-	mdbOpts.DB = "amboy-benchmarks"
+	mdbOpts.DB = "amboy_benchmarks"
 	queueOpts := queue.MongoDBQueueCreationOptions{
 		Size: runtime.NumCPU(),
 		Name: uuid.New().String(),

--- a/glide.lock
+++ b/glide.lock
@@ -36,7 +36,7 @@ imports:
 - name: github.com/evergreen-ci/poplar
   version: 952cf7a06a66d844a5450c6db6802faeb0f1a72e
 - name: github.com/evergreen-ci/utility
-  version: aaeb41d8ac416e8989f5d3175d2c2b607bed1aed
+  version: ea9a6354cebb635c026d8dbc7621c35622bb10c4
 
 - name: go.mongodb.org/mongo-driver
   version: 90164f879ba927bc0fa38682215b7a71d4ff8a92

--- a/makefile
+++ b/makefile
@@ -159,6 +159,7 @@ vendor-clean:
 	rm -rf vendor/github.com/evergreen-ci/poplar/vendor/github.com/mongodb/amboy/
 	rm -rf vendor/github.com/evergreen-ci/poplar/vendor/github.com/mongodb/grip/
 	rm -rf vendor/github.com/evergreen-ci/utility/file.go
+	rm -rf vendor/github.com/evergreen-ci/utility/gitignore.go
 	rm -rf vendor/github.com/evergreen-ci/utility/http.go
 	rm -rf vendor/github.com/evergreen-ci/utility/network.go
 	rm -rf vendor/github.com/evergreen-ci/utility/parsing.go

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -33,8 +33,7 @@ func TestManagerSuiteBackedByMongoDB(t *testing.T) {
 	name := uuid.New().String()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	opts := queue.DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
+	opts := defaultMongoDBTestOptions()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(opts.URI))
 	require.NoError(t, err)
 	s.factory = func() Manager {
@@ -74,8 +73,7 @@ func TestManagerSuiteBackedByMongoDBSingleGroup(t *testing.T) {
 	name := uuid.New().String()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	opts := queue.DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
+	opts := defaultMongoDBTestOptions()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(opts.URI))
 	require.NoError(t, err)
 	s.factory = func() Manager {
@@ -120,8 +118,7 @@ func TestManagerSuiteBackedByMongoDBMultiGroup(t *testing.T) {
 	name := uuid.New().String()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	opts := queue.DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
+	opts := defaultMongoDBTestOptions()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(opts.URI))
 	require.NoError(t, err)
 	s.factory = func() Manager {

--- a/management/mongodb_test.go
+++ b/management/mongodb_test.go
@@ -12,6 +12,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+func defaultMongoDBTestOptions() queue.MongoDBOptions {
+	opts := queue.DefaultMongoDBOptions()
+	opts.DB = "amboy_test"
+	return opts
+}
+
 func TestMongoDBConstructors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -21,8 +27,7 @@ func TestMongoDBConstructors(t *testing.T) {
 	require.NoError(t, client.Connect(ctx))
 
 	t.Run("NilSessionShouldError", func(t *testing.T) {
-		opts := queue.DefaultMongoDBOptions()
-		opts.DB = "amboy_test"
+		opts := defaultMongoDBTestOptions()
 		conf := DBQueueManagerOptions{Options: opts}
 
 		db, err := MakeDBQueueManager(ctx, conf, nil)
@@ -30,8 +35,7 @@ func TestMongoDBConstructors(t *testing.T) {
 		assert.Nil(t, db)
 	})
 	t.Run("UnpingableSessionError", func(t *testing.T) {
-		opts := queue.DefaultMongoDBOptions()
-		opts.DB = "amboy_test"
+		opts := defaultMongoDBTestOptions()
 		conf := DBQueueManagerOptions{Options: opts}
 
 		db, err := MakeDBQueueManager(ctx, conf, client)
@@ -39,8 +43,7 @@ func TestMongoDBConstructors(t *testing.T) {
 		assert.Nil(t, db)
 	})
 	t.Run("BuildNewConnector", func(t *testing.T) {
-		opts := queue.DefaultMongoDBOptions()
-		opts.DB = "amboy_test"
+		opts := defaultMongoDBTestOptions()
 		conf := DBQueueManagerOptions{Name: "foo", Options: opts}
 
 		db, err := MakeDBQueueManager(ctx, conf, client)
@@ -53,8 +56,7 @@ func TestMongoDBConstructors(t *testing.T) {
 		assert.NotZero(t, r.collection)
 	})
 	t.Run("DialWithNewConstructor", func(t *testing.T) {
-		opts := queue.DefaultMongoDBOptions()
-		opts.DB = "amboy_test"
+		opts := defaultMongoDBTestOptions()
 		conf := DBQueueManagerOptions{Name: "foo", Options: opts}
 
 		r, err := NewDBQueueManager(ctx, conf)
@@ -62,8 +64,7 @@ func TestMongoDBConstructors(t *testing.T) {
 		assert.NotNil(t, r)
 	})
 	t.Run("DialWithBadURI", func(t *testing.T) {
-		opts := queue.DefaultMongoDBOptions()
-		opts.DB = "amboy_test"
+		opts := defaultMongoDBTestOptions()
 		opts.URI = "mongodb://lochost:26016"
 		conf := DBQueueManagerOptions{Options: opts}
 

--- a/queue/dispatcher_test.go
+++ b/queue/dispatcher_test.go
@@ -139,7 +139,7 @@ func TestDispatcherImplementations(t *testing.T) {
 		}
 	}
 
-	opts := DefaultMongoDBOptions()
+	opts := defaultMongoDBTestOptions()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(opts.URI))
 	require.NoError(t, err)
 

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func defaultMongoDBTestOptions() MongoDBOptions {
+	opts := DefaultMongoDBOptions()
+	opts.DB = "amboy_test"
+	return opts
+}
+
 // All drivers should be able to pass this suite of tests which
 // exercise the complete functionality of the interface, without
 // reaching into the implementation details of any specific interface.
@@ -38,8 +44,7 @@ func TestDriverSuiteWithMongoDBInstance(t *testing.T) {
 		"Basic": {
 			constructor: func() (remoteQueueDriver, error) {
 				id := "test-" + uuid.New().String()
-				opts := DefaultMongoDBOptions()
-				opts.DB = "amboy_test"
+				opts := defaultMongoDBTestOptions()
 
 				return newMongoDriver(id, opts)
 			},
@@ -58,12 +63,11 @@ func TestDriverSuiteWithMongoDBInstance(t *testing.T) {
 
 			},
 		},
-		"Grouped": {
+		"Group": {
 			constructor: func() (remoteQueueDriver, error) {
 				id := "test-" + uuid.New().String()
 				groupName := "group-" + uuid.New().String()
-				opts := DefaultMongoDBOptions()
-				opts.DB = "amboy_test"
+				opts := defaultMongoDBTestOptions()
 				opts.UseGroups = true
 				opts.GroupName = groupName
 
@@ -793,7 +797,7 @@ func (s *DriverSuite) TestReturnsDefaultLockTimeout() {
 }
 
 func (s *DriverSuite) TestInfoReturnsConfigurableLockTimeout() {
-	opts := DefaultMongoDBOptions()
+	opts := defaultMongoDBTestOptions()
 	opts.LockTimeout = 25 * time.Minute
 	d, err := newMongoDriver(s.T().Name(), opts)
 	s.Require().NoError(err)

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -14,12 +14,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func defaultMongoDBTestOptions() MongoDBOptions {
-	opts := DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
-	return opts
-}
-
 // All drivers should be able to pass this suite of tests which
 // exercise the complete functionality of the interface, without
 // reaching into the implementation details of any specific interface.

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -411,7 +411,14 @@ func TestQueueSmoke(t *testing.T) {
 				}
 
 				t.Run(runner.Name+"Pool", func(t *testing.T) {
-					var testRetryOnce, testWaitUntilOnce, testDispatchBeforeOnce, testMaxTimeOnce, testScopesOnce, testApplyScopesOnEnqueueOnce sync.Once
+					var (
+						testRetryOnce                sync.Once
+						testWaitUntilOnce            sync.Once
+						testDispatchBeforeOnce       sync.Once
+						testMaxTimeOnce              sync.Once
+						testScopesOnce               sync.Once
+						testApplyScopesOnEnqueueOnce sync.Once
+					)
 
 					for _, size := range DefaultSizeTestCases() {
 						if test.MaxSize > 0 && size.Size > test.MaxSize {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -175,7 +175,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 					Size:    size,
 					Name:    name,
 					Ordered: false,
-					MDB:     DefaultMongoDBOptions(),
+					MDB:     defaultMongoDBTestOptions(),
 					Client:  client,
 				}
 				opts.MDB.Format = amboy.BSON2
@@ -212,7 +212,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 					Size:    size,
 					Name:    name,
 					Ordered: false,
-					MDB:     DefaultMongoDBOptions(),
+					MDB:     defaultMongoDBTestOptions(),
 					Client:  client,
 				}
 				opts.MDB.Format = amboy.BSON2
@@ -252,7 +252,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 					Size:    size,
 					Name:    name,
 					Ordered: false,
-					MDB:     DefaultMongoDBOptions(),
+					MDB:     defaultMongoDBTestOptions(),
 					Client:  client,
 				}
 				opts.MDB.Format = amboy.BSON
@@ -290,7 +290,7 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 					Size:    size,
 					Name:    name,
 					Ordered: true,
-					MDB:     DefaultMongoDBOptions(),
+					MDB:     defaultMongoDBTestOptions(),
 					Client:  client,
 				}
 				opts.MDB.Format = amboy.BSON2

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -411,6 +411,8 @@ func TestQueueSmoke(t *testing.T) {
 				}
 
 				t.Run(runner.Name+"Pool", func(t *testing.T) {
+					var testRetryOnce, testWaitUntilOnce, testDispatchBeforeOnce, testMaxTimeOnce, testScopesOnce, testApplyScopesOnEnqueueOnce sync.Once
+
 					for _, size := range DefaultSizeTestCases() {
 						if test.MaxSize > 0 && size.Size > test.MaxSize {
 							continue
@@ -440,25 +442,33 @@ func TestQueueSmoke(t *testing.T) {
 								})
 							}
 							if test.WaitUntilSupported {
-								t.Run("WaitUntil", func(t *testing.T) {
-									WaitUntilTest(bctx, t, test, runner, size)
+								testWaitUntilOnce.Do(func() {
+									t.Run("WaitUntil", func(t *testing.T) {
+										WaitUntilTest(bctx, t, test, runner, size)
+									})
 								})
 							}
 
 							if test.DispatchBeforeSupported {
-								t.Run("DispatchBefore", func(t *testing.T) {
-									DispatchBeforeTest(bctx, t, test, runner, size)
+								testDispatchBeforeOnce.Do(func() {
+									t.Run("DispatchBefore", func(t *testing.T) {
+										DispatchBeforeTest(bctx, t, test, runner, size)
+									})
 								})
 							}
 							if test.MaxTimeSupported {
-								t.Run("MaxTime", func(t *testing.T) {
-									MaxTimeTest(bctx, t, test, runner, size)
+								testMaxTimeOnce.Do(func() {
+									t.Run("MaxTime", func(t *testing.T) {
+										MaxTimeTest(bctx, t, test, runner, size)
+									})
 								})
 							}
 
 							if test.RetrySupported && size.Size >= 2 {
-								t.Run("Retry", func(t *testing.T) {
-									RetryableTest(bctx, t, test, runner, size)
+								testRetryOnce.Do(func() {
+									t.Run("Retry", func(t *testing.T) {
+										RetryableTest(bctx, t, test, runner, size)
+									})
 								})
 							}
 
@@ -467,14 +477,18 @@ func TestQueueSmoke(t *testing.T) {
 							})
 
 							if test.ScopesSupported {
-								if test.SingleWorker && (!test.OrderedSupported || test.OrderedStartsBefore) && size.Size >= 4 && size.Size <= 32 {
-									t.Run("ScopedLock", func(t *testing.T) {
-										ScopedLockTest(bctx, t, test, runner, size)
+								if test.SingleWorker && (!test.OrderedSupported || test.OrderedStartsBefore) && size.Size >= 4 {
+									testScopesOnce.Do(func() {
+										t.Run("ScopedLock", func(t *testing.T) {
+											ScopedLockTest(bctx, t, test, runner, size)
+										})
 									})
 								}
-								if size.Size <= 4 {
-									t.Run("ApplyScopesOnEnqueue", func(t *testing.T) {
-										ApplyScopesOnEnqueueTest(bctx, t, test, runner, size)
+								if size.Size >= 2 {
+									testApplyScopesOnEnqueueOnce.Do(func() {
+										t.Run("ApplyScopesOnEnqueue", func(t *testing.T) {
+											ApplyScopesOnEnqueueTest(bctx, t, test, runner, size)
+										})
 									})
 								}
 							}

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -238,7 +238,7 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) {
 						"retry_count": count,
 						"message":     "after 10 retries, aborting marking job complete",
 					}))
-				} else if isMongoDupKey(err) {
+				} else if isMongoDupKey(err) || isMongoNoDocumentsMatched(err) {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"job_id":      id,
 						"driver_type": q.driverType,
@@ -288,7 +288,7 @@ func (q *remoteBase) CompleteRetrying(ctx context.Context, j amboy.RetryableJob)
 
 			if err := q.driver.Complete(ctx, j); err != nil {
 				catcher.Wrapf(err, "attempt %d", attempt)
-				if isMongoDupKey(err) {
+				if isMongoDupKey(err) || isMongoNoDocumentsMatched(err) {
 					j.AddError(catcher.Resolve())
 					return errors.Wrapf(catcher.Resolve(), "giving up after attempt %d", attempt)
 				}

--- a/queue/remote_ordered_test.go
+++ b/queue/remote_ordered_test.go
@@ -36,8 +36,7 @@ func TestSimpleRemoteOrderedSuiteMongoDB(t *testing.T) {
 
 func (s *SimpleRemoteOrderedSuite) SetupSuite() {
 	name := "test-" + uuid.New().String()
-	opts := DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
+	opts := defaultMongoDBTestOptions()
 	s.driverConstructor = func() (remoteQueueDriver, error) {
 		return newMongoDriver(name, opts)
 	}

--- a/queue/remote_unordered_test.go
+++ b/queue/remote_unordered_test.go
@@ -33,8 +33,7 @@ type RemoteUnorderedSuite struct {
 func TestRemoteUnorderedMongoSuite(t *testing.T) {
 	tests := new(RemoteUnorderedSuite)
 	name := "test-" + uuid.New().String()
-	opts := DefaultMongoDBOptions()
-	opts.DB = "amboy_test"
+	opts := defaultMongoDBTestOptions()
 
 	tests.driverConstructor = func() (remoteQueueDriver, error) {
 		return newMongoDriver(name, opts)
@@ -341,7 +340,7 @@ func (s *RemoteUnorderedSuite) TestInfoReturnsDefaultLockTimeout() {
 }
 
 func (s *RemoteUnorderedSuite) TestInfoReturnsConfigurableLockTimeout() {
-	opts := DefaultMongoDBOptions()
+	opts := defaultMongoDBTestOptions()
 	opts.LockTimeout = 30 * time.Minute
 	d, err := newMongoDriver(s.T().Name(), opts)
 	s.Require().NoError(err)

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // statsRetryHandler is the same as an amboy.RetryHandler but allows it to
@@ -300,7 +299,7 @@ func (rh *basicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Retryabl
 		rh.prepareNewRetryJob(newJob)
 
 		err = rh.queue.CompleteRetryingAndPut(ctx, j, newJob)
-		if amboy.IsDuplicateJobError(err) || errors.Cause(err) == mongo.ErrNoDocuments {
+		if amboy.IsDuplicateJobError(err) || isMongoNoDocumentsMatched(err) {
 			return false, err
 		} else if err != nil {
 			return true, errors.Wrap(err, "enqueueing retry job")

--- a/queue/util_for_test.go
+++ b/queue/util_for_test.go
@@ -1,0 +1,26 @@
+package queue
+
+import (
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
+)
+
+func defaultMongoDBTestOptions() MongoDBOptions {
+	opts := DefaultMongoDBOptions()
+	opts.DB = "amboy_test"
+	return opts
+}
+
+func bsonJobTimeInfo(i amboy.JobTimeInfo) amboy.JobTimeInfo {
+	i.Created = utility.BSONTime(i.Created)
+	i.Start = utility.BSONTime(i.Start)
+	i.End = utility.BSONTime(i.End)
+	i.WaitUntil = utility.BSONTime(i.WaitUntil)
+	i.DispatchBy = utility.BSONTime(i.DispatchBy)
+	return i
+}
+
+func bsonJobStatusInfo(i amboy.JobStatusInfo) amboy.JobStatusInfo {
+	i.ModificationTime = utility.BSONTime(i.ModificationTime)
+	return i
+}

--- a/vendor/github.com/evergreen-ci/utility/LICENSE
+++ b/vendor/github.com/evergreen-ci/utility/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 MongoDB, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/evergreen-ci/utility/optional.go
+++ b/vendor/github.com/evergreen-ci/utility/optional.go
@@ -156,7 +156,10 @@ func FromStringPtr(in *string) string {
 
 // ToStringPtr returns a slice of string pointers from a slice of strings.
 func ToStringPtrSlice(in []string) []*string {
-	var res []*string
+	if in == nil {
+		return nil
+	}
+	res := []*string{}
 	for _, each := range in {
 		res = append(res, ToStringPtr(each))
 	}
@@ -166,7 +169,10 @@ func ToStringPtrSlice(in []string) []*string {
 // FromStringPtrSlice returns a slice of strings from a slice of string
 // pointers.
 func FromStringPtrSlice(in []*string) []string {
-	var res []string
+	if in == nil {
+		return nil
+	}
+	res := []string{}
 	for _, each := range in {
 		res = append(res, FromStringPtr(each))
 	}

--- a/vendor/github.com/evergreen-ci/utility/time.go
+++ b/vendor/github.com/evergreen-ci/utility/time.go
@@ -32,9 +32,16 @@ func FromNanoseconds(duration time.Duration) int64 {
 	return int64(duration) / 1000000
 }
 
-// fromNanoSeconds returns milliseconds of a duration for queries in the database.
+// ToNanoSeconds returns milliseconds of a duration for queries in the database.
 func ToNanoseconds(duration time.Duration) time.Duration {
 	return duration * 1000000
+}
+
+// BSONTime converts a timestamp to how it would be represented in BSON such
+// that, if the resulting timestamp is roundtripped to BSON and back, the
+// timestamps would be identical.
+func BSONTime(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Millisecond)
 }
 
 // FromPythonTime returns a time.Time that corresponds to the float style


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13784
Patch: https://evergreen.mongodb.com/version/6037d7ae3e8e8669cc1ed35f

* Add integration tests for retry handler and remote queue.
* Add temporary internal interface for checking runtime stats of retry handler. I might get rid of it after [EVG-14111](https://jira.mongodb.org/browse/EVG-14111), since I mostly wanted it for more convenient testing.
* Reduce the amount of duplicate smok tests run.