### PR TITLE
EVG-14111: add retry metadata for start/end times

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -185,6 +185,10 @@ type JobRetryInfo struct {
 	// execution. The job will not run until this waiting period elapses. This
 	// is analogous to (JobTimeInfo).WaitUntil.
 	WaitUntil time.Duration `bson:"wait_until,omitempty" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
+	// Start is the time that the job began retrying.
+	Start time.Time `bson:"start,omitempty" json:"start,omitempty" yaml:"start,omitempty"`
+	// End is the time that the job finished retrying.
+	End time.Time `bson:"end,omitempty" json:"end,omitempty" yaml:"end,omitempty"`
 }
 
 // Options returns a JobRetryInfo as its equivalent JobRetryOptions. In other
@@ -198,6 +202,8 @@ func (info *JobRetryInfo) Options() JobRetryOptions {
 		MaxAttempts:    &info.MaxAttempts,
 		DispatchBy:     &info.DispatchBy,
 		WaitUntil:      &info.WaitUntil,
+		Start:          &info.Start,
+		End:            &info.End,
 	}
 }
 
@@ -222,6 +228,8 @@ type JobRetryOptions struct {
 	MaxAttempts    *int           `bson:"-" json:"-" yaml:"-"`
 	DispatchBy     *time.Duration `bson:"-" json:"-" yaml:"-"`
 	WaitUntil      *time.Duration `bson:"-" json:"-" yaml:"-"`
+	Start          *time.Time     `bson:"-" json:"-" yaml:"-"`
+	End            *time.Time     `bson:"-" json:"-" yaml:"-"`
 }
 
 // Duration is a convenience function to return a duration for a job.

--- a/job/base.go
+++ b/job/base.go
@@ -357,4 +357,10 @@ func (b *Base) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.WaitUntil != nil {
 		b.retryInfo.WaitUntil = *opts.WaitUntil
 	}
+	if opts.Start != nil {
+		b.retryInfo.Start = *opts.Start
+	}
+	if opts.End != nil {
+		b.retryInfo.End = *opts.End
+	}
 }

--- a/makefile
+++ b/makefile
@@ -185,7 +185,7 @@ phony += vendor-clean
 
 # clean and other utility targets
 clean:
-	rm -rf $(name) $(lintDeps) $(buildDir)/output.*
+	rm -rf $(lintDeps) $(buildDir)/output.*
 phony += clean
 # end dependency targets
 

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -181,6 +181,7 @@ func (q *remoteBase) CompleteRetryingAndPut(ctx context.Context, toComplete, toP
 func (q *remoteBase) prepareCompleteRetrying(j amboy.RetryableJob) {
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		NeedsRetry: utility.FalsePtr(),
+		End:        utility.ToTimePtr(time.Now()),
 	})
 }
 

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -186,4 +186,19 @@ func (j *JobTest) UpdateRetryInfo(opts amboy.JobRetryOptions) {
 	if opts.CurrentAttempt != nil {
 		j.Retry.CurrentAttempt = *opts.CurrentAttempt
 	}
+	if opts.MaxAttempts != nil {
+		j.Retry.MaxAttempts = *opts.MaxAttempts
+	}
+	if opts.DispatchBy != nil {
+		j.Retry.DispatchBy = *opts.DispatchBy
+	}
+	if opts.WaitUntil != nil {
+		j.Retry.WaitUntil = *opts.WaitUntil
+	}
+	if opts.Start != nil {
+		j.Retry.Start = *opts.Start
+	}
+	if opts.End != nil {
+		j.Retry.End = *opts.End
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14111
Patch: https://evergreen.mongodb.com/version/603954f5e3c33156027ee2c1

* Add timing metadata for retrying.
* Remove temporary statsRetryHandler interface