### PR TITLE
EVG-13922: make stale retrying monitor configurable and add debug logging for retry handler

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -372,6 +372,10 @@ type RetryableQueue interface {
 	// to change RetryHandler implementations after starting the Queue.
 	SetRetryHandler(RetryHandler) error
 
+	// SetStaleRetryingMonitorInterval configures how frequently the
+	// RetryableQueue should be checked for jobs that are retrying but stale.
+	SetStaleRetryingMonitorInterval(time.Duration)
+
 	// GetAttempt returns the job associated with the given attempt of the job
 	// and a bool indicating whether the job was found or not.
 	GetAttempt(ctx context.Context, id string, attempt int) (RetryableJob, bool)

--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -131,6 +131,10 @@ func (opts MongoDBQueueGroupOptions) validate() error {
 	if opts.DefaultWorkers == 0 && opts.WorkerPoolSize == nil {
 		catcher.New("must specify either a default worker pool size or a WorkerPoolSize function")
 	}
+	catcher.NewWhen(opts.StaleRetryingCheckFrequency < 0, "stale retrying check frequency cannot be negative")
+	if opts.StaleRetryingCheckFrequency == 0 {
+		opts.StaleRetryingCheckFrequency = defaultStaleRetryingMonitorInterval
+	}
 	return catcher.Resolve()
 }
 

--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -47,8 +47,12 @@ type MongoDBQueueGroupOptions struct {
 	// to each queue, based on the queue ID passed to it.
 	WorkerPoolSize func(string) int
 
-	// RetryHandlerOpts configure how retryable jobs are handled.
+	// RetryHandler configure how retryable jobs are handled.
 	RetryHandler amboy.RetryHandlerOptions
+
+	// StaleRetryingCheckFrequency is how often queues periodically check for
+	// stale retrying jobs.
+	StaleRetryingCheckFrequency time.Duration
 
 	// PruneFrequency is how often Prune runs by default.
 	PruneFrequency time.Duration
@@ -89,12 +93,16 @@ func (opts *MongoDBQueueGroupOptions) constructor(ctx context.Context, name stri
 			return nil, errors.Wrap(err, "configuring queue with runner")
 		}
 	}
+
 	rh, err := newBasicRetryHandler(q, opts.RetryHandler)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing retry handler")
 	}
 	if err = q.SetRetryHandler(rh); err != nil {
 		return nil, errors.Wrap(err, "configuring queue with retry handler")
+	}
+	if opts.StaleRetryingCheckFrequency != 0 {
+		q.SetStaleRetryingMonitorInterval(opts.StaleRetryingCheckFrequency)
 	}
 
 	return q, nil

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -121,6 +121,10 @@ func (q *mockRemoteQueue) SetRetryHandler(rh amboy.RetryHandler) error {
 	return rh.SetQueue(q)
 }
 
+func (q *mockRemoteQueue) SetStaleRetryingMonitorInterval(interval time.Duration) {
+	q.remoteQueue.SetStaleRetryingMonitorInterval(interval)
+}
+
 func (q *mockRemoteQueue) Put(ctx context.Context, j amboy.Job) error {
 	if q.putJob != nil {
 		return q.putJob(ctx, q.remoteQueue, j)

--- a/queue/remote.go
+++ b/queue/remote.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
@@ -19,6 +20,9 @@ type MongoDBQueueCreationOptions struct {
 	MDB          MongoDBOptions
 	Client       *mongo.Client
 	RetryHandler amboy.RetryHandlerOptions
+	// StaleRetryingCheckFrequency is how often the queue periodically checks
+	// for stale retrying jobs.
+	StaleRetryingCheckFrequency time.Duration
 }
 
 // NewMongoDBQueue builds a new queue that persists jobs to a MongoDB

--- a/queue/remote.go
+++ b/queue/remote.go
@@ -45,6 +45,11 @@ func (opts *MongoDBQueueCreationOptions) Validate() error {
 	catcher.NewWhen(opts.Client == nil && (opts.MDB.URI == "" && opts.MDB.DB == ""),
 		"must specify database options")
 
+	catcher.NewWhen(opts.StaleRetryingCheckFrequency < 0, "stale retrying check frequency cannot be negative")
+	if opts.StaleRetryingCheckFrequency == 0 {
+		opts.StaleRetryingCheckFrequency = defaultStaleRetryingMonitorInterval
+	}
+
 	return catcher.Resolve()
 }
 

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -273,13 +273,13 @@ func TestRetryHandlerImplementations(t *testing.T) {
 
 					assert.Error(t, rh.Put(ctx, nil))
 				},
-				"PutFailsWithDuplicateJob": func(ctx context.Context, t *testing.T, makeQueueAndRetryHandler func(opts amboy.RetryHandlerOptions) (*mockRemoteQueue, amboy.RetryHandler, error)) {
+				"PutIsIdempotent": func(ctx context.Context, t *testing.T, makeQueueAndRetryHandler func(opts amboy.RetryHandlerOptions) (*mockRemoteQueue, amboy.RetryHandler, error)) {
 					_, rh, err := makeQueueAndRetryHandler(amboy.RetryHandlerOptions{})
 					require.NoError(t, err)
 
 					j := newMockRetryableJob("id")
 					require.NoError(t, rh.Put(ctx, j))
-					assert.Error(t, rh.Put(ctx, j))
+					assert.NoError(t, rh.Put(ctx, j))
 				},
 				"MaxRetryAttemptsLimitsEnqueueAttempts": func(ctx context.Context, t *testing.T, makeQueueAndRetryHandler func(opts amboy.RetryHandlerOptions) (*mockRemoteQueue, amboy.RetryHandler, error)) {
 					opts := amboy.RetryHandlerOptions{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13922

* Add an option to set how frequently the monitor checks for stale retrying jobs.
* Add debug logging to help diagnose issues during rollout. They might be removed later once it's stable.