### PR TITLE
EVG-14169: merge RetryableJob into Job interface

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -23,56 +23,55 @@ func jitterNilJobWait() time.Duration {
 
 }
 
-func executeJob(ctx context.Context, id string, job amboy.Job, q amboy.Queue) {
+func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 	var jobCtx context.Context
-	if maxTime := job.TimeInfo().MaxTime; maxTime > 0 {
+	if maxTime := j.TimeInfo().MaxTime; maxTime > 0 {
 		var jobCancel context.CancelFunc
 		jobCtx, jobCancel = context.WithTimeout(ctx, maxTime)
 		defer jobCancel()
 	} else {
 		jobCtx = ctx
 	}
-	job.Run(jobCtx)
-	q.Complete(ctx, job)
-	amboy.WithRetryableJob(job, func(rj amboy.RetryableJob) {
-		amboy.WithRetryableQueue(q, func(rq amboy.RetryableQueue) {
-			if !rj.RetryInfo().Retryable || !rj.RetryInfo().NeedsRetry {
-				return
-			}
+	j.Run(jobCtx)
+	q.Complete(ctx, j)
 
-			rh := rq.RetryHandler()
-			if rh == nil {
-				grip.Error(message.Fields{
-					"message":  "cannot retry a job in a queue that does not support retrying",
-					"job_id":   rj.ID(),
-					"queue_id": rq.ID(),
-				})
-				return
-			}
+	amboy.WithRetryableQueue(q, func(rq amboy.RetryableQueue) {
+		if !j.RetryInfo().ShouldRetry() {
+			return
+		}
 
-			if err := rh.Put(ctx, rj); err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message":  "could not prepare job for retry",
-					"job_id":   rj.ID(),
-					"queue_id": rq.ID(),
-				}))
-			}
-		})
+		rh := rq.RetryHandler()
+		if rh == nil {
+			grip.Error(message.Fields{
+				"message":  "cannot retry a job in a queue that does not support retrying",
+				"job_id":   j.ID(),
+				"queue_id": rq.ID(),
+			})
+			return
+		}
+
+		if err := rh.Put(ctx, j); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":  "could not prepare job for retry",
+				"job_id":   j.ID(),
+				"queue_id": rq.ID(),
+			}))
+		}
 	})
 
-	ti := job.TimeInfo()
+	ti := j.TimeInfo()
 	r := message.Fields{
-		"job_id":        job.ID(),
-		"job_type":      job.Type().Name,
+		"job_id":        j.ID(),
+		"job_type":      j.Type().Name,
 		"duration_secs": ti.Duration().Seconds(),
 		"dispatch_secs": ti.Start.Sub(ti.Created).Seconds(),
 		"pending_secs":  ti.End.Sub(ti.Created).Seconds(),
 		"queue_type":    fmt.Sprintf("%T", q),
-		"stat":          job.Status(),
+		"stat":          j.Status(),
 		"pool":          id,
 		"max_time_secs": ti.MaxTime.Seconds(),
 	}
-	err := job.Error()
+	err := j.Error()
 	if err != nil {
 		r["error"] = err.Error()
 	}

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -18,10 +18,9 @@ type remoteQueueDriver interface {
 	// Get finds a job by job ID. For retryable jobs, this returns the latest
 	// job attempt.
 	Get(context.Context, string) (amboy.Job, error)
-	// GetAttempt returns a job by job ID and attempt number. Only applicable to
-	// retryable jobs. If used for a non-retryable job, this should return nil
-	// and an error.
-	GetAttempt(ctx context.Context, id string, attempt int) (amboy.RetryableJob, error)
+	// GetAttempt returns a retryable job by job ID and attempt number. If used
+	// to find a non-retryable job, this should return nil job and an error.
+	GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, error)
 	// Put inserts a new job in the backing storage.
 	Put(context.Context, amboy.Job) error
 	// Save updates an existing job in the backing storage. Implementations may
@@ -34,7 +33,7 @@ type remoteQueueDriver interface {
 
 	Jobs(context.Context) <-chan amboy.Job
 	// RetryableJobs returns retryable jobs, subject to a filter.
-	RetryableJobs(context.Context, RetryableJobFilter) <-chan amboy.RetryableJob
+	RetryableJobs(context.Context, retryableJobFilter) <-chan amboy.Job
 	Next(context.Context) amboy.Job
 
 	Stats(context.Context) amboy.QueueStats
@@ -47,20 +46,21 @@ type remoteQueueDriver interface {
 	Dispatcher() Dispatcher
 }
 
-// RetryableJobFilter represents a filter on jobs that are currently retrying.
-type RetryableJobFilter string
+// retryableJobFilter represents a query filter on retryable jobs.
+type retryableJobFilter string
 
 const (
 	// RetryableJobAll refers to all retryable jobs.
-	RetryableJobAll RetryableJobFilter = "all"
-	// RetryableJobAllRetrying refers to all jobs that are currently waiting to
-	// retry.
-	RetryableJobAllRetrying RetryableJobFilter = "all-retrying"
-	// RetryableJobActiveRetrying refers to jobs that have recently retried.
-	RetryableJobActiveRetrying RetryableJobFilter = "active-retrying"
-	// RetryableJobStaleRetrying refers to jobs that should be retrying but have
-	// not done so recently.
-	RetryableJobStaleRetrying RetryableJobFilter = "stale-retrying"
+	retryableJobAll retryableJobFilter = "all-retryable"
+	// RetryableJobAllRetrying refers to all retryable jobs that are currently
+	// waiting to retry.
+	retryableJobAllRetrying retryableJobFilter = "all-retrying"
+	// RetryableJobActiveRetrying refers to retryable jobs that have recently
+	// retried.
+	retryableJobActiveRetrying retryableJobFilter = "active-retrying"
+	// RetryableJobStaleRetrying refers to retryable jobs that should be
+	// retrying but have not done so recently.
+	retryableJobStaleRetrying retryableJobFilter = "stale-retrying"
 )
 
 // MongoDBOptions is a struct passed to the NewMongo constructor to

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -127,7 +127,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					})
 
 					var calledGetAttempt, calledSave, calledCompleteRetrying, calledCompleteRetryingAndPut bool
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						calledGetAttempt = true
 						ji, err := registry.MakeJobInterchange(j, amboy.JSON)
 						if err != nil {
@@ -137,13 +137,9 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						if err != nil {
 							return nil, false
 						}
-						rj, ok := j.(amboy.RetryableJob)
-						if !ok {
-							return nil, false
-						}
-						return rj, true
+						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						calledCompleteRetrying = true
 						return nil
 					}
@@ -151,7 +147,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						calledSave = true
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(_ context.Context, _ remoteQueue, toComplete, toPut amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(_ context.Context, _ remoteQueue, toComplete, toPut amboy.Job) error {
 						calledCompleteRetryingAndPut = true
 
 						assert.Zero(t, toComplete.RetryInfo().CurrentAttempt)
@@ -179,7 +175,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					mq, rh, err := makeQueueAndRetryHandler(amboy.RetryHandlerOptions{})
 					require.NoError(t, err)
 					var calledMockQueue bool
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						calledMockQueue = true
 						return nil, false
 					}
@@ -187,7 +183,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						calledMockQueue = true
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						calledMockQueue = true
 						return nil
 					}
@@ -204,11 +200,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 
 					j := newMockRetryableJob("id")
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
@@ -216,7 +212,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -241,7 +237,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						MaxAttempts:    utility.ToIntPtr(10),
 					})
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
@@ -249,11 +245,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -295,11 +291,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					})
 
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
@@ -307,7 +303,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -336,11 +332,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					})
 
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
@@ -348,7 +344,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -381,11 +377,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					})
 
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
@@ -393,7 +389,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -424,11 +420,11 @@ func TestRetryHandlerImplementations(t *testing.T) {
 					})
 
 					var getAttemptCalls, saveCalls, completeRetryingCalls, completeRetryingAndPutCalls int
-					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.RetryableJob, bool) {
+					mq.getJobAttempt = func(context.Context, remoteQueue, string, int) (amboy.Job, bool) {
 						getAttemptCalls++
 						return j, true
 					}
-					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.RetryableJob) error {
+					mq.completeRetryingJob = func(context.Context, remoteQueue, amboy.Job) error {
 						completeRetryingCalls++
 						return nil
 					}
@@ -436,7 +432,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 						saveCalls++
 						return nil
 					}
-					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.RetryableJob, amboy.RetryableJob) error {
+					mq.completeRetryingAndPutJob = func(context.Context, remoteQueue, amboy.Job, amboy.Job) error {
 						completeRetryingAndPutCalls++
 						return errors.New("fail")
 					}
@@ -868,16 +864,14 @@ func TestRetryHandlerQueueIntegration(t *testing.T) {
 
 							ji, err := registry.MakeJobInterchange(j, amboy.JSON)
 							require.NoError(t, err)
-							jobCopy, err := ji.Resolve(amboy.JSON)
+							retryJob, err := ji.Resolve(amboy.JSON)
 							require.NoError(t, err)
-							jobRetry, ok := jobCopy.(amboy.RetryableJob)
-							require.True(t, ok, "job should be retryable")
-							jobRetry.UpdateRetryInfo(amboy.JobRetryOptions{
+							retryJob.UpdateRetryInfo(amboy.JobRetryOptions{
 								NeedsRetry:     utility.FalsePtr(),
 								CurrentAttempt: utility.ToIntPtr(1),
 							})
 
-							require.NoError(t, q.Put(ctx, jobRetry))
+							require.NoError(t, q.Put(ctx, retryJob))
 
 							retryProcessed := make(chan struct{})
 							go func() {
@@ -903,9 +897,9 @@ func TestRetryHandlerQueueIntegration(t *testing.T) {
 								assert.Equal(t, 2, q.Stats(ctx).Total)
 								storedJob, ok := q.GetAttempt(ctx, j.ID(), 1)
 								require.True(t, ok)
-								assert.Equal(t, bsonJobTimeInfo(jobRetry.TimeInfo()), bsonJobTimeInfo(storedJob.TimeInfo()))
-								assert.Equal(t, bsonJobStatusInfo(jobRetry.Status()), bsonJobStatusInfo(storedJob.Status()))
-								assert.Equal(t, jobRetry.RetryInfo(), jobRetry.RetryInfo())
+								assert.Equal(t, bsonJobTimeInfo(retryJob.TimeInfo()), bsonJobTimeInfo(storedJob.TimeInfo()))
+								assert.Equal(t, bsonJobStatusInfo(retryJob.Status()), bsonJobStatusInfo(storedJob.Status()))
+								assert.Equal(t, retryJob.RetryInfo(), retryJob.RetryInfo())
 							}
 						},
 						"RetryNoopsIfJobInQueueDoesNotNeedToRetry": func(ctx context.Context, t *testing.T, makeQueueAndRetryHandler func(opts amboy.RetryHandlerOptions) (remoteQueue, amboy.RetryHandler, error)) {

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -44,11 +44,6 @@ func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 		return nil, err
 	}
 
-	var retryInfo amboy.JobRetryInfo
-	amboy.WithRetryableJob(j, func(rj amboy.RetryableJob) {
-		retryInfo = rj.RetryInfo()
-	})
-
 	output := &JobInterchange{
 		Name:                 j.ID(),
 		Type:                 typeInfo.Name,
@@ -57,7 +52,7 @@ func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 		Status:               j.Status(),
 		TimeInfo:             j.TimeInfo(),
 		ApplyScopesOnEnqueue: j.ShouldApplyScopesOnEnqueue(),
-		RetryInfo:            retryInfo,
+		RetryInfo:            j.RetryInfo(),
 		Job:                  data,
 		Dependency:           dep,
 	}
@@ -99,9 +94,7 @@ func (j *JobInterchange) Resolve(f amboy.Format) (amboy.Job, error) {
 	job.SetStatus(j.Status)
 	job.SetShouldApplyScopesOnEnqueue(j.ApplyScopesOnEnqueue)
 	job.UpdateTimeInfo(j.TimeInfo)
-	amboy.WithRetryableJob(job, func(rj amboy.RetryableJob) {
-		rj.UpdateRetryInfo(j.RetryInfo.Options())
-	})
+	job.UpdateRetryInfo(j.RetryInfo.Options())
 
 	return job, nil
 }

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -39,10 +38,6 @@ func TestJobInterchangeSuiteBSON(t *testing.T) {
 	s := new(JobInterchangeSuite)
 	s.format = amboy.BSON2
 	suite.Run(t, s)
-}
-
-func TestJobInterfaceSatisfaction(t *testing.T) {
-	assert.Implements(t, (*amboy.RetryableJob)(nil), NewTestJob(""))
 }
 
 func (s *JobInterchangeSuite) SetupTest() {

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -1,6 +1,6 @@
 package registry
 
-// This file has a mock implementation of a RetryableJob. Used in other tests.
+// This file has a mock implementation of an amboy.Job. Used in other tests.
 
 import (
 	"context"

--- a/rest/service_queue_job.go
+++ b/rest/service_queue_job.go
@@ -49,10 +49,7 @@ func (s *QueueService) getJobStatusResponse(ctx context.Context, name string) (*
 		return resp, err
 	}
 
-	completed := j.Status().Completed
-	amboy.WithRetryableJob(j, func(rj amboy.RetryableJob) {
-		completed = completed && !rj.RetryInfo().NeedsRetry
-	})
+	completed := j.Status().Completed && (!j.RetryInfo().ShouldRetry())
 
 	resp.Exists = true
 	resp.Completed = completed

--- a/retry.go
+++ b/retry.go
@@ -1,22 +1,8 @@
 package amboy
 
-// WithRetryableJob is a convenience function to perform an operation if the Job
-// is a RetryableJob; otherwise, it is a no-op. Returns whether or not the job
-// was a RetryableJob.
-func WithRetryableJob(j Job, op func(RetryableJob)) bool {
-	rj, ok := j.(RetryableJob)
-	if !ok {
-		return false
-	}
-
-	op(rj)
-
-	return true
-}
-
 // WithRetryableQueue is a convenience function to perform an operation if the
-// Job is a RetryableJob; otherwise, it is a no-op. Returns whether ot not the
-// queue was a RetryableQueue.
+// Queue is a RetryableQueue; otherwise, it is a no-op. Returns whether ot not
+// the queue was a RetryableQueue.
 func WithRetryableQueue(q Queue, op func(RetryableQueue)) bool {
 	rq, ok := q.(RetryableQueue)
 	if !ok {

--- a/wait.go
+++ b/wait.go
@@ -99,12 +99,8 @@ func WaitJob(ctx context.Context, j Job, q Queue) bool {
 			return false
 		}
 
-		rj, ok := j.(RetryableJob)
-		if ok && rj.RetryInfo().NeedsRetry {
-			continue
-		}
-
-		if j.Status().Completed {
+		completed := j.Status().Completed && j.RetryInfo().ShouldRetry()
+		if completed {
 			return true
 		}
 	}
@@ -131,13 +127,9 @@ func WaitJobInterval(ctx context.Context, j Job, q Queue, interval time.Duration
 				return false
 			}
 
-			rj, ok := j.(RetryableJob)
-			if ok && rj.RetryInfo().NeedsRetry {
-				timer.Reset(interval)
-				continue
-			}
+			completed := j.Status().Completed && !j.RetryInfo().ShouldRetry()
 
-			if j.Status().Completed {
+			if completed {
 				return true
 			}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14169
Patch: https://evergreen.mongodb.com/version/603d5a0f3066154680414970

I was originally hoping to be able to separate the retryable job from the non-retryable job more cleanly. However, it's not really possible to enforce that statically with an interface. It also had a problem where, even if you had a RetryableJob, retryability hinged mostly on the queue's built-in support for it. Instead of relying on a compile-time mechanism to deal with retryable jobs, I'm instead just going to use the `(JobRetryInfo).Retryable` feature flag as the marker for a retryable job.