### PR TITLE
EVG-14184: do not count in progress jobs as pending in queue stats

### DIFF
--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -555,7 +555,7 @@ func (s *DriverSuite) TestStatsCountsAreAccurate() {
 	}
 
 	stats := s.driver.Stats(s.ctx)
-	s.Equal(numEnqueued+numRunning, stats.Pending)
+	s.Equal(numEnqueued, stats.Pending)
 	s.Equal(numRunning, stats.Running)
 	s.Equal(numCompleted+numRetrying, stats.Completed)
 	s.Equal(numRetrying, stats.Retrying)
@@ -588,7 +588,7 @@ func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 	s.NoError(s.driver.Put(s.ctx, j))
 	s.Equal(1, s.driver.Stats(s.ctx).Total)
 	s.Equal(0, s.driver.Stats(s.ctx).Blocked)
-	s.Equal(1, s.driver.Stats(s.ctx).Pending)
+	s.Equal(1, s.driver.Stats(s.ctx).Running)
 	s.Equal(0, s.driver.Stats(s.ctx).Completed)
 
 	s.Nil(s.driver.Next(ctx), fmt.Sprintf("%T", s.driver))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14184

Pending should refer to jobs that are neither in progress nor completed. When I copied the query from the original stats code into the aggregation, the old code incorrectly counted in progress jobs as "pending" (which I assumed was correct, but it seems like it's just a bug). This fixes the stats to correctly count pending jobs as it's actually defined.