### PR TITLE
EVG-14082: Increase logging level for important information

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -79,7 +79,7 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 	if err != nil {
 		grip.Error(r)
 	} else {
-		grip.Debug(r)
+		grip.Info(r)
 	}
 }
 

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1066,7 +1066,7 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 			qd = d.getNextQuery()
 			iter, err := d.getCollection().Find(ctx, qd, opts)
 			if err != nil {
-				grip.Debug(message.WrapError(err, message.Fields{
+				grip.Warning(message.WrapError(err, message.Fields{
 					"id":            d.instanceID,
 					"service":       "amboy.queue.mdb",
 					"operation":     "retrieving next job",


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14082

I increased the logging level to `info` in `executeJob` when there is no error and an error log's level to `warning` in the mongo go driver.