### PR TITLE
EVG-14244: change job status method to return more job information

### DIFF
--- a/management/interface.go
+++ b/management/interface.go
@@ -27,13 +27,13 @@ type Manager interface {
 // current jobs in a queue by status
 type StatusFilter string
 
-// nolint
+// Constants representing StatusFilters
 const (
 	InProgress StatusFilter = "in-progress"
-	Pending                 = "pending"
-	Stale                   = "stale"
-	Completed               = "completed"
-	All                     = "all"
+	Pending    StatusFilter = "pending"
+	Stale      StatusFilter = "stale"
+	Completed  StatusFilter = "completed"
+	All        StatusFilter = "all"
 )
 
 // Validate returns an error if a filter value is not valid.
@@ -50,11 +50,11 @@ func (t StatusFilter) Validate() error {
 // the reporting interface.
 type RuntimeFilter string
 
-// nolint
+// Constants representing RuntimeFilters.
 const (
 	Duration RuntimeFilter = "completed"
-	Latency                = "latency"
-	Running                = "running"
+	Latency  RuntimeFilter = "latency"
+	Running  RuntimeFilter = "running"
 )
 
 // Validate returns an error if a filter value is not valid.
@@ -71,11 +71,11 @@ func (t RuntimeFilter) Validate() error {
 // in error queries.
 type ErrorFilter string
 
-// nolint
+// Constants representing ErrorFilters.
 const (
 	UniqueErrors ErrorFilter = "unique-errors"
-	AllErrors                = "all-errors"
-	StatsOnly                = "stats-only"
+	AllErrors    ErrorFilter = "all-errors"
+	StatsOnly    ErrorFilter = "stats-only"
 )
 
 // Validate returns an error if a filter value is not valid.

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -291,16 +291,16 @@ func (s *ManagerSuite) TestCompleteJob() {
 
 	s.Require().NoError(s.manager.CompleteJob(s.ctx, "complete"))
 	jobCount := 0
-	for jobStats := range s.queue.JobStats(s.ctx) {
-		if jobStats.ID == "complete" {
-			s.True(jobStats.Completed)
+	for info := range s.queue.JobInfo(s.ctx) {
+		if info.ID == "complete" {
+			s.True(info.Status.Completed)
 			_, ok := s.manager.(*dbQueueManager)
 			if ok {
-				s.Equal(3, jobStats.ModificationCount)
+				s.Equal(3, info.Status.ModificationCount)
 			}
 		} else {
-			s.False(jobStats.Completed)
-			s.Equal(0, jobStats.ModificationCount)
+			s.False(info.Status.Completed)
+			s.Equal(0, info.Status.ModificationCount)
 		}
 		jobCount++
 	}
@@ -322,11 +322,11 @@ func (s *ManagerSuite) TestCompleteJobsValidFilter() {
 
 	s.Require().NoError(s.manager.CompleteJobs(s.ctx, Pending))
 	jobCount := 0
-	for jobStats := range s.queue.JobStats(s.ctx) {
-		s.True(jobStats.Completed)
+	for info := range s.queue.JobInfo(s.ctx) {
+		s.True(info.Status.Completed)
 		_, ok := s.manager.(*dbQueueManager)
 		if ok {
-			s.Equal(3, jobStats.ModificationCount)
+			s.Equal(3, info.Status.ModificationCount)
 		}
 		jobCount++
 	}
@@ -348,16 +348,16 @@ func (s *ManagerSuite) TestCompleteJobsByTypeValidFilter() {
 
 	s.Require().NoError(s.manager.CompleteJobsByType(s.ctx, Pending, "test"))
 	jobCount := 0
-	for jobStats := range s.queue.JobStats(s.ctx) {
-		if jobStats.ID == "0" || jobStats.ID == "1" {
-			s.True(jobStats.Completed)
+	for info := range s.queue.JobInfo(s.ctx) {
+		if info.ID == "0" || info.ID == "1" {
+			s.True(info.Status.Completed)
 			_, ok := s.manager.(*dbQueueManager)
 			if ok {
-				s.Equal(3, jobStats.ModificationCount)
+				s.Equal(3, info.Status.ModificationCount)
 			}
 		} else {
-			s.False(jobStats.Completed)
-			s.Equal(0, jobStats.ModificationCount)
+			s.False(info.Status.Completed)
+			s.Equal(0, info.Status.ModificationCount)
 		}
 		jobCount++
 	}
@@ -379,16 +379,16 @@ func (s *ManagerSuite) TestCompleteJobsByPrefixValidFilter() {
 
 	s.Require().NoError(s.manager.CompleteJobsByPrefix(s.ctx, Pending, "pre"))
 	jobCount := 0
-	for jobStats := range s.queue.JobStats(s.ctx) {
-		if jobStats.ID == "pre-one" || jobStats.ID == "pre-two" {
-			s.True(jobStats.Completed)
+	for info := range s.queue.JobInfo(s.ctx) {
+		if info.ID == "pre-one" || info.ID == "pre-two" {
+			s.True(info.Status.Completed)
 			_, ok := s.manager.(*dbQueueManager)
 			if ok {
-				s.Equal(3, jobStats.ModificationCount)
+				s.Equal(3, info.Status.ModificationCount)
 			}
 		} else {
-			s.False(jobStats.Completed)
-			s.Equal(0, jobStats.ModificationCount)
+			s.False(info.Status.Completed)
+			s.Equal(0, info.Status.ModificationCount)
 		}
 		jobCount++
 	}

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -37,7 +37,7 @@ type remoteQueueDriver interface {
 	Next(context.Context) amboy.Job
 
 	Stats(context.Context) amboy.QueueStats
-	JobStats(context.Context) <-chan amboy.JobStatusInfo
+	JobInfo(context.Context) <-chan amboy.JobInfo
 	Complete(context.Context, amboy.Job) error
 
 	LockTimeout() time.Duration

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -794,7 +794,7 @@ func (s *DriverSuite) TestRetryableJobsReturnsStaleRetryingJobs() {
 	s.Empty(foundUnexpected, "found unexpected IDs %s", foundUnexpected)
 }
 
-func (s *DriverSuite) TestJobStatsMethodReturnsAllJobs() {
+func (s *DriverSuite) TestJobInfoMethodReturnsAllJobs() {
 	names := make(map[string]struct{})
 
 	for i := 0; i < 30; i++ {
@@ -808,8 +808,8 @@ func (s *DriverSuite) TestJobStatsMethodReturnsAllJobs() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	counter := 0
-	for stat := range s.driver.JobStats(ctx) {
-		_, ok := names[stat.ID]
+	for info := range s.driver.JobInfo(ctx) {
+		_, ok := names[info.ID]
 		s.True(ok)
 		counter++
 	}

--- a/queue/limited.go
+++ b/queue/limited.go
@@ -222,7 +222,7 @@ func (q *limitedSizeLocal) Results(ctx context.Context) <-chan amboy.Job {
 	return out
 }
 
-// JobInfo returns a channel for infomration on all jobs in the queue. Job
+// JobInfo returns a channel for information on all jobs in the queue. Job
 // information is returned in no particular order.
 func (q *limitedSizeLocal) JobInfo(ctx context.Context) <-chan amboy.JobInfo {
 	q.mu.RLock()

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -45,7 +45,7 @@ type mockRemoteQueue struct {
 	completeJob               func(ctx context.Context, q remoteQueue, j amboy.Job)
 	completeRetryingJob       func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	jobResults                func(ctx context.Context, q remoteQueue) <-chan amboy.Job
-	jobStats                  func(ctx context.Context, q remoteQueue) <-chan amboy.JobStatusInfo
+	jobInfo                   func(ctx context.Context, q remoteQueue) <-chan amboy.JobInfo
 	queueStats                func(ctx context.Context, q remoteQueue) amboy.QueueStats
 	queueInfo                 func(q remoteQueue) amboy.QueueInfo
 	startQueue                func(ctx context.Context, q remoteQueue) error
@@ -189,11 +189,11 @@ func (q *mockRemoteQueue) Results(ctx context.Context) <-chan amboy.Job {
 	return q.remoteQueue.Results(ctx)
 }
 
-func (q *mockRemoteQueue) JobStats(ctx context.Context) <-chan amboy.JobStatusInfo {
-	if q.jobStats != nil {
-		return q.jobStats(ctx, q.remoteQueue)
+func (q *mockRemoteQueue) JobInfo(ctx context.Context) <-chan amboy.JobInfo {
+	if q.jobInfo != nil {
+		return q.jobInfo(ctx, q.remoteQueue)
 	}
-	return q.remoteQueue.JobStats(ctx)
+	return q.remoteQueue.JobInfo(ctx)
 }
 
 func (q *mockRemoteQueue) Stats(ctx context.Context) amboy.QueueStats {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -636,11 +636,11 @@ func UnorderedTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 	}
 
 	statCounter := 0
-	for stat := range q.JobStats(ctx) {
+	for info := range q.JobInfo(ctx) {
 		statCounter++
-		assert.True(t, stat.ID != "")
+		assert.NotEmpty(t, info.ID)
 	}
-	assert.Equal(t, numJobs, statCounter, fmt.Sprintf("want jobStats for every job"))
+	assert.Equal(t, numJobs, statCounter, fmt.Sprintf("want job info for every job"))
 
 	grip.Infof("completed results check for %d worker smoke test", size.Size)
 }
@@ -694,9 +694,9 @@ func OrderedTest(bctx context.Context, t *testing.T, test QueueTestCase, runner 
 	}
 
 	statCounter := 0
-	for stat := range q.JobStats(ctx) {
+	for info := range q.JobInfo(ctx) {
 		statCounter++
-		require.True(t, stat.ID != "")
+		require.NotEmpty(t, info.ID)
 	}
 	require.Equal(t, statCounter, numJobs)
 }

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -336,8 +336,11 @@ func (q *remoteBase) Results(ctx context.Context) <-chan amboy.Job {
 	return output
 }
 
-func (q *remoteBase) JobStats(ctx context.Context) <-chan amboy.JobStatusInfo {
-	return q.driver.JobStats(ctx)
+// JobInfo returns a channel that produces information about all jobs in the
+// queue. The order in which job information is produced depends on the backing
+// storage driver.
+func (q *remoteBase) JobInfo(ctx context.Context) <-chan amboy.JobInfo {
+	return q.driver.JobInfo(ctx)
 }
 
 // Stats returns a amboy.QueueStats object that reflects the progress

--- a/queue/remote_unordered_test.go
+++ b/queue/remote_unordered_test.go
@@ -298,7 +298,7 @@ checkResults:
 	s.Equal(created, observed+numLocked, "%+v", qStat)
 }
 
-func (s *RemoteUnorderedSuite) TestJobStatsIterator() {
+func (s *RemoteUnorderedSuite) TestJobInfo() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.Require().NoError(s.queue.SetDriver(s.driver))
@@ -314,8 +314,8 @@ func (s *RemoteUnorderedSuite) TestJobStatsIterator() {
 	}
 
 	counter := 0
-	for stat := range s.queue.JobStats(ctx) {
-		_, ok := names[stat.ID]
+	for info := range s.queue.JobInfo(ctx) {
+		_, ok := names[info.ID]
 		s.True(ok)
 		counter++
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14244

* Rename `JobStats` to `JobInfo`.
   * Instead of just returning the job status info, return more of the available information from the job.
   * Move `JobStatusInfo.ID` to `JobInfo`, because it doesn't really belong on `JobStatusInfo`.
* Fix context handling in queue implementations for `JobStats` (`JobInfo`).
* Fix a few small correctness bugs in the queue-based remote management implementation.
* Add more docs and fix some existing ones.