### PR TITLE
EVG-14245: add method to get all job attempts

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,17 +19,17 @@ func (e *JobNotFoundError) Error() string { return e.msg }
 
 // NewJobNotFoundError creates a new error indicating that a job could not be
 // found in the queue.
-func NewJobNotFoundError(msg string) error { return &JobNotFoundError{msg: msg} }
+func NewJobNotFoundError(msg string) *JobNotFoundError { return &JobNotFoundError{msg: msg} }
 
 // NewJobNotFoundErrorf creates a new error with a formatted message, indicating
 // that a job could not be found in the queue.
-func NewJobNotFoundErrorf(msg string, args ...interface{}) error {
+func NewJobNotFoundErrorf(msg string, args ...interface{}) *JobNotFoundError {
 	return NewJobNotFoundError(fmt.Sprintf(msg, args...))
 }
 
 // MakeJobNotFoundError constructs an error from an existing one, indicating
 // that a job could not be found in the queue.
-func MakeJobNotFoundError(err error) error {
+func MakeJobNotFoundError(err error) *JobNotFoundError {
 	if err == nil {
 		return nil
 	}

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,43 @@ import (
 	"github.com/pkg/errors"
 )
 
+type JobNotFoundError struct {
+	msg string
+}
+
+func (e *JobNotFoundError) Error() string { return e.msg }
+
+// NewJobNotFoundError creates a new error indicating that a job could not be
+// found in the queue.
+func NewJobNotFoundError(msg string) error { return &JobNotFoundError{msg: msg} }
+
+// NewJobNotFoundErrorf creates a new error with a formatted message, indicating
+// that a job could not be found in the queue.
+func NewJobNotFoundErrorf(msg string, args ...interface{}) error {
+	return NewJobNotFoundError(fmt.Sprintf(msg, args...))
+}
+
+// MakeJobNotFoundError constructs an error from an existing one, indicating
+// that a job could not be found in the queue.
+func MakeJobNotFoundError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return NewJobNotFoundError(err.Error())
+}
+
+// IsJobNotFound tests an error it is due tonot being able to find a job in the
+// queue.
+func IsJobNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := errors.Cause(err).(*JobNotFoundError)
+	return ok
+}
+
 // EnqueueUniqueJob is a generic wrapper for adding jobs to queues (using the
 // Put() method), but that ignores duplicate job errors.
 func EnqueueUniqueJob(ctx context.Context, queue Queue, job Job) error {
@@ -25,19 +62,18 @@ type duplJobError struct {
 
 func (e *duplJobError) Error() string { return e.msg }
 
-// NewDuplicateJobError creates a new error object to represent a
-// duplicate job error, for use by queue implementations.
+// NewDuplicateJobError creates a new error to represent a duplicate job error,
+// for use by queue implementations.
 func NewDuplicateJobError(msg string) error { return &duplJobError{msg: msg} }
 
-// NewDuplicateJobErrorf creates a new error object to represent a
-// duplicate job error with a formatted message, for use by queue
-// implementations.
+// NewDuplicateJobErrorf creates a new error to represent a duplicate job error
+// with a formatted message, for use by queue implementations.
 func NewDuplicateJobErrorf(msg string, args ...interface{}) error {
 	return NewDuplicateJobError(fmt.Sprintf(msg, args...))
 }
 
-// MakeDuplicateJobError constructs a duplicate job error from an
-// existing error of any type, for use by queue implementations.
+// MakeDuplicateJobError constructs a duplicate job error from an existing error
+// of any type, for use by queue implementations.
 func MakeDuplicateJobError(err error) error {
 	if err == nil {
 		return nil
@@ -46,8 +82,7 @@ func MakeDuplicateJobError(err error) error {
 	return NewDuplicateJobError(err.Error())
 }
 
-// IsDuplicateJobError tests an error object to see if it is a
-// duplicate job error.
+// IsDuplicateJobError tests an error to see if it is a duplicate job error.
 func IsDuplicateJobError(err error) bool {
 	if err == nil {
 		return false

--- a/errors.go
+++ b/errors.go
@@ -7,10 +7,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+// JobNotFoundError represents an error indicating that a job could not be found
+// in a queue.
 type JobNotFoundError struct {
 	msg string
 }
 
+// Error returns the error message from the job not found error to provide more
+// context as to why the job was not found.
 func (e *JobNotFoundError) Error() string { return e.msg }
 
 // NewJobNotFoundError creates a new error indicating that a job could not be
@@ -33,8 +37,8 @@ func MakeJobNotFoundError(err error) error {
 	return NewJobNotFoundError(err.Error())
 }
 
-// IsJobNotFound tests an error it is due tonot being able to find a job in the
-// queue.
+// IsJobNotFound checks if an error was due to not being able to find the job
+// in the queue.
 func IsJobNotFoundError(err error) bool {
 	if err == nil {
 		return false
@@ -82,7 +86,8 @@ func MakeDuplicateJobError(err error) error {
 	return NewDuplicateJobError(err.Error())
 }
 
-// IsDuplicateJobError tests an error to see if it is a duplicate job error.
+// IsDuplicateJobError checks if an error is due to a duplicate job in the
+// queue.
 func IsDuplicateJobError(err error) bool {
 	if err == nil {
 		return false
@@ -123,8 +128,8 @@ func MakeDuplicateJobScopeError(err error) error {
 	return NewDuplicateJobScopeError(err.Error())
 }
 
-// IsDuplicateJobScopeError tests an error object to see if it is a duplicate
-// job scope error.
+// IsDuplicateJobScopeError checks if an error is due to a duplicate job scope
+// in the queue.
 func IsDuplicateJobScopeError(err error) bool {
 	if err == nil {
 		return false

--- a/errors_test.go
+++ b/errors_test.go
@@ -48,3 +48,25 @@ func TestDuplicateError(t *testing.T) {
 		assert.True(t, IsDuplicateJobScopeError(err))
 	})
 }
+
+func TestJobNotFoundError(t *testing.T) {
+	t.Run("RegularErrorIsNotJobNotFound", func(t *testing.T) {
+		err := errors.New("err")
+		assert.False(t, IsJobNotFoundError(err))
+	})
+	t.Run("NilErrorIsNotDuplicate", func(t *testing.T) {
+		assert.False(t, IsJobNotFoundError(nil))
+	})
+	t.Run("NewJobNotFoundError", func(t *testing.T) {
+		err := NewJobNotFoundError("err")
+		assert.True(t, IsJobNotFoundError(err))
+	})
+	t.Run("NewJobNotFoundErrorf", func(t *testing.T) {
+		err := NewJobNotFoundErrorf("err %s", "err")
+		assert.True(t, IsJobNotFoundError(err))
+	})
+	t.Run("MakeJobNotFoundError", func(t *testing.T) {
+		err := MakeJobNotFoundError(errors.New("err"))
+		assert.True(t, IsJobNotFoundError(err))
+	})
+}

--- a/interface.go
+++ b/interface.go
@@ -213,7 +213,7 @@ const defaultRetryableMaxAttempts = 10
 
 // GetMaxAttempts returns the maximum number of times a job is allowed to
 // attempt. It defaults the maximum attempts if it's unset.
-func (info *JobRetryInfo) GetMaxAttempts() int {
+func (info JobRetryInfo) GetMaxAttempts() int {
 	if info.MaxAttempts <= 0 {
 		return defaultRetryableMaxAttempts
 	}
@@ -379,10 +379,15 @@ type RetryableQueue interface {
 	// RetryableQueue should be checked for jobs that are retrying but stale.
 	SetStaleRetryingMonitorInterval(time.Duration)
 
-	// GetAttempt returns the retryable job associated with the given attempt of
-	// the job and a bool indicating whether the job was found or not. This will
-	// only return retryable jobs.
-	GetAttempt(ctx context.Context, id string, attempt int) (Job, bool)
+	// GetAttempt returns the retryable job associated with the given ID and
+	// execution attempt. If it cannot find a matching job, it will return
+	// ErrJobNotFound. This will only return retryable jobs.
+	GetAttempt(ctx context.Context, id string, attempt int) (Job, error)
+
+	// GetAllAttempts returns all execution attempts of a retryable job
+	// associated with the given job ID. If it cannot find a matching job, it
+	// will return ErrJobNotFound.This will only return retryable jobs.
+	GetAllAttempts(ctx context.Context, id string) ([]Job, error)
 
 	// CompleteRetryingAndPut marks an existing job toComplete in the queue (see
 	// CompleteRetrying) as finished retrying and inserts a new job toPut in the

--- a/periodic_test.go
+++ b/periodic_test.go
@@ -17,13 +17,13 @@ func TestWaitUntil(t *testing.T) {
 	t.Run("PastStartAt", func(t *testing.T) {
 		tsa := time.Now().Round(time.Second)
 		waitUntilInterval(ctx, time.Now().Round(time.Second).Add(-interval), interval)
-		assert.WithinDuration(t, tsa.Add(interval), time.Now(), time.Second)
+		assert.WithinDuration(t, tsa.Add(interval), time.Now(), interval)
 		assert.True(t, tsa.Before(time.Now()))
 	})
 	t.Run("FutureStartAt", func(t *testing.T) {
 		tsa := time.Now().Round(time.Second)
 		waitUntilInterval(ctx, time.Now().Round(time.Second).Add(interval), interval)
-		assert.WithinDuration(t, tsa.Add(interval), time.Now(), time.Second)
+		assert.WithinDuration(t, tsa.Add(interval), time.Now(), interval)
 		assert.True(t, tsa.Before(time.Now()))
 	})
 	t.Run("Cancelable", func(t *testing.T) {

--- a/queue/adaptive_order.go
+++ b/queue/adaptive_order.go
@@ -124,7 +124,7 @@ func (q *adaptiveLocalOrdering) Save(ctx context.Context, j amboy.Job) error {
 	op := func(ctx context.Context, items *adaptiveOrderItems, fixed *fixedStorage) {
 		defer close(out)
 		if _, ok := items.jobs[name]; !ok {
-			out <- errors.New("cannot save job that does not exist")
+			out <- amboy.NewJobNotFoundError("cannot save job that does not exist")
 			return
 		}
 

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -21,6 +21,9 @@ type remoteQueueDriver interface {
 	// GetAttempt returns a retryable job by job ID and attempt number. If used
 	// to find a non-retryable job, this should return nil job and an error.
 	GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, error)
+	// GetAllAttempts returns all attempts of a retryable job by job ID. If used
+	// to find a non-retryable job, this should return no jobs and an error.
+	GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error)
 	// Put inserts a new job in the backing storage.
 	Put(context.Context, amboy.Job) error
 	// Save updates an existing job in the backing storage. Implementations may
@@ -86,12 +89,15 @@ type MongoDBOptions struct {
 	LockTimeout time.Duration
 }
 
+// defaultMongoDBURI is the default URI to connect to a MongoDB instance.
+const defaultMongoDBURI = "mongodb://localhost:27017"
+
 // DefaultMongoDBOptions constructs a new options object with default
 // values: connecting to a MongoDB instance on localhost, using the
 // "amboy" database, and *not* using priority ordering of jobs.
 func DefaultMongoDBOptions() MongoDBOptions {
 	return MongoDBOptions{
-		URI:                      "mongodb://localhost:27017",
+		URI:                      defaultMongoDBURI,
 		DB:                       "amboy",
 		Priority:                 false,
 		UseGroups:                false,

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -534,7 +534,7 @@ func (d *mongoDriver) GetAllAttempts(ctx context.Context, id string) ([]amboy.Jo
 	}
 	d.modifyQueryForGroup(matchID)
 
-	sortAttempt := bson.M{"retry_info.current_attempt": 1}
+	sortAttempt := bson.M{"retry_info.current_attempt": -1}
 
 	cursor, err := d.getCollection().Find(ctx, matchID, options.Find().SetSort(sortAttempt))
 	if err != nil {
@@ -549,13 +549,13 @@ func (d *mongoDriver) GetAllAttempts(ctx context.Context, id string) ([]amboy.Jo
 		return nil, amboy.NewJobNotFoundError("no such job found")
 	}
 
-	jobs := make([]amboy.Job, 0, len(jobInts))
-	for _, ji := range jobInts {
+	jobs := make([]amboy.Job, len(jobInts))
+	for i, ji := range jobInts {
 		j, err := ji.Resolve(d.opts.Format)
 		if err != nil {
 			return nil, errors.Wrap(err, "converting serialized job format to in-memory job")
 		}
-		jobs = append(jobs, j)
+		jobs[len(jobs)-i-1] = j
 	}
 
 	return jobs, nil

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -495,30 +495,70 @@ func (d *mongoDriver) Get(ctx context.Context, name string) (amboy.Job, error) {
 	return output, nil
 }
 
-func (d *mongoDriver) GetAttempt(ctx context.Context, name string, attempt int) (amboy.Job, error) {
+// GetAttempt finds a retryable job matching the given job ID and execution
+// attempt. This returns an error if no matching job is found.
+func (d *mongoDriver) GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, error) {
 	matchIDAndAttempt := bson.M{
-		"retry_info.base_job_id":     name,
+		"retry_info.base_job_id":     id,
 		"retry_info.current_attempt": attempt,
 	}
 	d.modifyQueryForGroup(matchIDAndAttempt)
 
 	res := d.getCollection().FindOne(ctx, matchIDAndAttempt)
 	if err := res.Err(); err != nil {
-		return nil, errors.Wrapf(err, "GET problem fetching '%s'", name)
+		if err == mongo.ErrNoDocuments {
+			return nil, amboy.NewJobNotFoundError("no such job found")
+		}
+		return nil, errors.Wrap(err, "finding job attempt")
 	}
 
 	ji := &registry.JobInterchange{}
 	if err := res.Decode(ji); err != nil {
-		return nil, errors.Wrapf(err, "GET problem decoding '%s'", name)
+		return nil, errors.Wrap(err, "decoding job")
 	}
 
 	j, err := ji.Resolve(d.opts.Format)
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"GET problem converting '%s' to job object", name)
+		return nil, errors.Wrap(err, "converting serialized job format to in-memory job")
 	}
 
 	return j, nil
+}
+
+// GetAllAttempts finds all execution attempts of a retryable job for a given
+// job ID. This returns an error if no matching job is found. The returned jobs
+// are sorted by increasing attempt number.
+func (d *mongoDriver) GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error) {
+	matchID := bson.M{
+		"retry_info.base_job_id": id,
+	}
+	d.modifyQueryForGroup(matchID)
+
+	sortAttempt := bson.M{"retry_info.current_attempt": 1}
+
+	cursor, err := d.getCollection().Find(ctx, matchID, options.Find().SetSort(sortAttempt))
+	if err != nil {
+		return nil, errors.Wrap(err, "finding all attempts")
+	}
+
+	jobInts := []registry.JobInterchange{}
+	if err := cursor.All(ctx, &jobInts); err != nil {
+		return nil, errors.Wrap(err, "decoding job")
+	}
+	if len(jobInts) == 0 {
+		return nil, amboy.NewJobNotFoundError("no such job found")
+	}
+
+	jobs := make([]amboy.Job, 0, len(jobInts))
+	for _, ji := range jobInts {
+		j, err := ji.Resolve(d.opts.Format)
+		if err != nil {
+			return nil, errors.Wrap(err, "converting serialized job format to in-memory job")
+		}
+		jobs = append(jobs, j)
+	}
+
+	return jobs, nil
 }
 
 func (d *mongoDriver) Put(ctx context.Context, j amboy.Job) error {
@@ -576,10 +616,6 @@ func (d *mongoDriver) getAtomicQuery(jobName string, modCount int) bson.M {
 }
 
 var errMongoNoDocumentsMatched = errors.New("no documents matched")
-
-func isMongoNoDocumentsMatched(err error) bool {
-	return errors.Cause(err) == errMongoNoDocumentsMatched
-}
 
 func isMongoDupKey(err error) bool {
 	dupKeyErrs := getMongoDupKeyErrors(err)
@@ -758,8 +794,9 @@ func (d *mongoDriver) doUpdate(ctx context.Context, ji *registry.JobInterchange)
 	}
 
 	if res.MatchedCount == 0 {
-		return errors.Wrapf(errMongoNoDocumentsMatched, "problem saving job [id=%s, matched=%d, modified=%d]", ji.Name, res.MatchedCount, res.ModifiedCount)
+		return amboy.NewJobNotFoundErrorf("unmatched job [id=%s, matched=%d, modified=%d]", ji.Name, res.MatchedCount, res.ModifiedCount)
 	}
+
 	return nil
 }
 

--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -29,8 +29,7 @@ func TestQueueGroup(t *testing.T) {
 	bctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const mdburl = "mongodb://localhost:27017"
-	client, cerr := mongo.NewClient(options.Client().ApplyURI(mdburl).SetConnectTimeout(2 * time.Second))
+	client, cerr := mongo.NewClient(options.Client().ApplyURI(defaultMongoDBURI).SetConnectTimeout(2 * time.Second))
 	require.NoError(t, cerr)
 	require.NoError(t, client.Connect(bctx))
 	defer func() { require.NoError(t, client.Disconnect(bctx)) }()
@@ -251,7 +250,7 @@ func TestQueueGroup(t *testing.T) {
 					mopts := MongoDBOptions{
 						WaitInterval: time.Millisecond,
 						DB:           "amboy_group_test",
-						URI:          "mongodb://localhost:27017",
+						URI:          defaultMongoDBURI,
 					}
 
 					closer := func(cctx context.Context) error {
@@ -284,7 +283,7 @@ func TestQueueGroup(t *testing.T) {
 				Constructor: func(ctx context.Context, ttl time.Duration) (amboy.QueueGroup, queueGroupCloser, error) {
 					mopts := MongoDBOptions{
 						DB:           "amboy_group_test",
-						URI:          "mongodb://localhost:27017",
+						URI:          defaultMongoDBURI,
 						WaitInterval: time.Millisecond,
 					}
 
@@ -603,7 +602,7 @@ func TestQueueGroup(t *testing.T) {
 			mopts := MongoDBOptions{
 				DB:           "amboy_group_test",
 				WaitInterval: time.Millisecond,
-				URI:          "mongodb://localhost:27017",
+				URI:          defaultMongoDBURI,
 			}
 
 			for i := 0; i < 10; i++ {

--- a/queue/limited.go
+++ b/queue/limited.go
@@ -109,7 +109,7 @@ func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {
 	defer q.mu.Unlock()
 
 	if _, ok := q.storage[name]; !ok {
-		return errors.Errorf("cannot save '%s', which is not tracked", name)
+		return amboy.NewJobNotFoundErrorf("cannot save '%s', which is not tracked", name)
 	}
 
 	if err := q.scopes.Acquire(name, j.Scopes()); err != nil {

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -149,7 +149,7 @@ func (q *limitedSizeSerializableLocal) Save(ctx context.Context, j amboy.Job) er
 	defer q.mu.Unlock()
 
 	if !q.jobStored(name) {
-		return errors.Errorf("cannot save '%s', which is not tracked", name)
+		return amboy.NewJobNotFoundError("job not found in queue storage")
 	}
 
 	if err := q.scopes.Acquire(name, j.Scopes()); err != nil {
@@ -191,7 +191,7 @@ func (q *limitedSizeSerializableLocal) Get(ctx context.Context, name string) (am
 	if !ok {
 		return nil, false
 	}
-	for attempt := 1; attempt < j.RetryInfo().MaxAttempts; attempt++ {
+	for attempt := 1; attempt < j.RetryInfo().GetMaxAttempts(); attempt++ {
 		nextRetryableName := q.getNameForAttempt(name, attempt)
 		nextAttempt, ok := q.getCopy(nextRetryableName)
 		if !ok {
@@ -203,17 +203,46 @@ func (q *limitedSizeSerializableLocal) Get(ctx context.Context, name string) (am
 	return j, true
 }
 
-func (q *limitedSizeSerializableLocal) GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, bool) {
+// GetAttempt returns the retryable job matching the given job ID and execution
+// attempt. If no such job is found, it will return an amboy.JobNotFoundError.
+func (q *limitedSizeSerializableLocal) GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, error) {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 
 	name := q.getNameForAttempt(id, attempt)
 	j, ok := q.getCopy(name)
 	if !ok {
-		return nil, false
+		return nil, amboy.NewJobNotFoundError("no such job found")
 	}
 
-	return j, ok
+	return j, nil
+}
+
+// GetAllAttempts returns all execution attempts of a retryable job matching the
+// given job ID. If no such job is found, it will return an
+// amboy.JobNotFoundError.
+func (q *limitedSizeSerializableLocal) GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	// Search incrementally until we cannot find a higher attempt.
+	name := q.getNameForAttempt(id, 0)
+	j, ok := q.getCopy(name)
+	if !ok {
+		return nil, amboy.NewJobNotFoundError("no such job found")
+	}
+	jobs := []amboy.Job{j}
+	for attempt := 1; attempt < j.RetryInfo().GetMaxAttempts(); attempt++ {
+		name := q.getNameForAttempt(id, attempt)
+		nextAttempt, ok := q.getCopy(name)
+		if !ok {
+			break
+		}
+		j = nextAttempt
+		jobs = append(jobs, nextAttempt)
+	}
+
+	return jobs, nil
 }
 
 // Next returns the next pending job, and is used by amboy.Runner
@@ -485,7 +514,7 @@ func (q *limitedSizeSerializableLocal) CompleteRetrying(ctx context.Context, j a
 
 	name := q.getNameWithMetadata(j)
 	if !q.jobStored(name) {
-		return nil
+		return amboy.NewJobNotFoundError("no such job exists")
 	}
 
 	if err := q.complete(ctx, j); err != nil {

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -38,7 +38,8 @@ type mockRemoteQueue struct {
 	// Mockable methods
 	putJob                    func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	getJob                    func(ctx context.Context, q remoteQueue, id string) (amboy.Job, bool)
-	getJobAttempt             func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.Job, bool)
+	getJobAttempt             func(ctx context.Context, q remoteQueue, id string, attempt int) (amboy.Job, error)
+	getAllJobAttempts         func(ctx context.Context, q remoteQueue, id string) ([]amboy.Job, error)
 	saveJob                   func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	completeRetryingAndPutJob func(ctx context.Context, q remoteQueue, toComplete, toPut amboy.Job) error
 	nextJob                   func(ctx context.Context, q remoteQueue) amboy.Job
@@ -139,11 +140,18 @@ func (q *mockRemoteQueue) Get(ctx context.Context, id string) (amboy.Job, bool) 
 	return q.remoteQueue.Get(ctx, id)
 }
 
-func (q *mockRemoteQueue) GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, bool) {
+func (q *mockRemoteQueue) GetAttempt(ctx context.Context, id string, attempt int) (amboy.Job, error) {
 	if q.getJobAttempt != nil {
 		return q.getJobAttempt(ctx, q.remoteQueue, id, attempt)
 	}
 	return q.remoteQueue.GetAttempt(ctx, id, attempt)
+}
+
+func (q *mockRemoteQueue) GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error) {
+	if q.getJobAttempt != nil {
+		return q.getAllJobAttempts(ctx, q.remoteQueue, id)
+	}
+	return q.remoteQueue.GetAllAttempts(ctx, id)
 }
 
 func (q *mockRemoteQueue) Save(ctx context.Context, j amboy.Job) error {

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -138,7 +138,7 @@ func (q *depGraphOrderedLocal) Save(ctx context.Context, j amboy.Job) error {
 	}
 
 	if _, ok := q.tasks.m[name]; !ok {
-		return errors.Errorf("cannot add %s because job does not exist", name)
+		return amboy.NewJobNotFoundErrorf("cannot add %s because job does not exist", name)
 	}
 
 	q.tasks.m[name] = j

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1250,13 +1250,13 @@ func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 				assert.Equal(t, 2, rq.Stats(ctx).Total)
 				assert.Equal(t, 2, rq.Stats(ctx).Completed)
 
-				rj0, ok := rq.GetAttempt(ctx, j.ID(), 0)
-				require.True(t, ok)
+				rj0, err := rq.GetAttempt(ctx, j.ID(), 0)
+				require.NoError(t, err)
 				assert.True(t, rj0.RetryInfo().Retryable)
 				assert.False(t, rj0.RetryInfo().NeedsRetry)
 
-				rj1, ok := rq.GetAttempt(ctx, j.ID(), 1)
-				require.True(t, ok)
+				rj1, err := rq.GetAttempt(ctx, j.ID(), 1)
+				require.NoError(t, err)
 				assert.True(t, rj1.RetryInfo().Retryable)
 				assert.False(t, rj1.RetryInfo().NeedsRetry)
 			}

--- a/queue/remote_ordered_test.go
+++ b/queue/remote_ordered_test.go
@@ -45,7 +45,7 @@ func (s *SimpleRemoteOrderedSuite) SetupSuite() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017").SetConnectTimeout(time.Second))
+		client, err := mongo.NewClient(options.Client().ApplyURI(defaultMongoDBURI).SetConnectTimeout(time.Second))
 		if err != nil {
 			return err
 		}

--- a/queue/shuffled.go
+++ b/queue/shuffled.go
@@ -182,7 +182,7 @@ func (q *shuffledLocal) Save(ctx context.Context, j amboy.Job) error {
 			return
 		}
 
-		ret <- errors.Errorf("job '%s' does not exist", id)
+		ret <- amboy.NewJobNotFoundErrorf("job '%s' does not exist", id)
 	}
 
 	select {

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -136,7 +136,7 @@ func (q *sqsFIFOQueue) Save(ctx context.Context, j amboy.Job) error {
 	}
 
 	if _, ok := q.tasks.all[name]; !ok {
-		return errors.Errorf("cannot save '%s' because a job does not exist with that name", name)
+		return amboy.NewJobNotFoundErrorf("cannot save '%s' because a job does not exist with that name", name)
 	}
 
 	q.tasks.all[name] = j

--- a/queue/util_for_test.go
+++ b/queue/util_for_test.go
@@ -29,3 +29,10 @@ func bsonJobStatusInfo(i amboy.JobStatusInfo) amboy.JobStatusInfo {
 	i.ModificationTime = utility.BSONTime(i.ModificationTime)
 	return i
 }
+
+// bsonJobRetryInfo converts all amboy.JobRetryInfo time fields into BSON time.
+func bsonJobRetryInfo(i amboy.JobRetryInfo) amboy.JobRetryInfo {
+	i.Start = utility.BSONTime(i.Start)
+	i.End = utility.BSONTime(i.End)
+	return i
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14245

* Add `GetAllAttempts` to get all attempted executions tied to a single job ID.
* Make retryable queue methods return errors instead of booleans.
* Add error type for job not found in queue and use it for `Save`, `GetAttempt`, and `GetAllAttempts`.
* I decided to move the retrying logic for `CompleteRetrying` out of the remote queue implementation because it seems like that should be handled at a higher level. I only had that because I copied it from `Complete` (which retries because it does not return errors).
* Add tests for RetryableQueue-specific interface.