### PR TITLE
EVG-14067: do not prune queue group that still has retrying jobs

### DIFF
--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -381,7 +381,13 @@ func (g *remoteMongoQueueGroup) Prune(ctx context.Context) error {
 				count, err := c.CountDocuments(ctx, bson.M{
 					"status.completed": true,
 					"status.in_prog":   false,
-					"status.mod_ts":    bson.M{"$gte": time.Now().Add(-g.opts.TTL)},
+					"$or": []bson.M{
+						{"status.mod_ts": bson.M{"$gte": time.Now().Add(-g.opts.TTL)}},
+						{
+							"retry_info.retryable":   true,
+							"retry_info.needs_retry": true,
+						},
+					},
 				})
 				if err != nil {
 					catcher.Add(err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14067

Change the (mock) implementation of the MongoDB queue group to take retrying jobs into account before pruning the queue.