### PR TITLE
EVG-14027: add feature flag for retryability

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,6 +28,10 @@ export GOROOT := $(goroot)
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
+
+.DEFAULT_GOAL := compile
+
+
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
@@ -44,14 +48,6 @@ $(buildDir)/run-benchmarks:cmd/run-benchmarks/run-benchmarks.go
 	$(gobin) build -o $@ $<
 # end benchmark setup targets
 
-
-######################################################################
-##
-## Everything below this point is generic, and does not contain
-## project specific configuration. (with one noted case in the "build"
-## target for library-only projects)
-##
-######################################################################
 
 _compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
@@ -73,8 +69,7 @@ coverage: $(coverageOutput)
 coverage-html: $(coverageHtmlOutput)
 compile $(buildDir):
 	$(gobin) build $(_compilePackages)
-compile-base:
-	$(gobin) build  ./
+phony += compile $(buildDir)
 # convenience targets for runing tests and coverage tasks on a
 # specific package.
 test-%:$(buildDir)/output.%.test
@@ -185,7 +180,7 @@ phony += vendor-clean
 
 # clean and other utility targets
 clean:
-	rm -rf $(lintDeps) $(buildDir)/output.*
+	rm -rf $(buildDir)
 phony += clean
 # end dependency targets
 

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -235,7 +235,7 @@ func TestManagerImplementations(t *testing.T) {
 		// },
 		"Queue-Backed": {
 			makeQueue: func(ctx context.Context) (amboy.Queue, error) {
-				return queue.NewLocalLimitedSizeSerializable(2, queueSize), nil
+				return queue.NewLocalLimitedSizeSerializable(2, queueSize)
 			},
 			makeManager: func(ctx context.Context, q amboy.Queue) (Manager, error) {
 				return NewQueueManager(q), nil

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -466,15 +466,13 @@ func (s *DriverSuite) TestCompleteAndPutJobsFailsWithDuplicateJobScopesAppliedOn
 
 func (s *DriverSuite) TestCompleteMarksJobCompleted() {
 	j := job.NewShellJob("echo foo", "")
-	now := time.Now()
 	j.SetStatus(amboy.JobStatusInfo{
-		InProgress:       true,
-		ModificationTime: now,
-		Owner:            s.driver.ID(),
+		InProgress: true,
+		Owner:      s.driver.ID(),
 	})
 	s.Require().NoError(s.driver.Put(s.ctx, j))
 	s.Require().NoError(s.driver.Complete(s.ctx, j))
-	s.NotEqual(utility.BSONTime(now), utility.BSONTime(j.Status().ModificationTime))
+	s.NotZero(utility.BSONTime(j.Status().ModificationTime))
 	s.Zero(j.Status().ModificationCount)
 }
 

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -430,8 +430,9 @@ func (q *limitedSizeSerializableLocal) RetryHandler() amboy.RetryHandler {
 	return q.retryHandler
 }
 
-// SetRetryHandler allows callers to inject a different retry handler
-// implementation if the queue has not yet started.
+// SetRetryHandler allows callers to inject alternative amboy.RetryHandler
+// instances if the queue has not yet started or if the queue is started but
+// does not already have a retry handler.
 func (q *limitedSizeSerializableLocal) SetRetryHandler(rh amboy.RetryHandler) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -27,16 +27,15 @@ import (
 // store no more than 2x the specified capacity. For completed jobs, will store
 // no more than the specified capacity.
 type limitedSizeSerializableLocal struct {
-	pending                      chan amboy.Job
-	started                      bool
-	toDelete                     []string
-	capacity                     int
-	storage                      map[string]amboy.Job
-	scopes                       ScopeManager
-	dispatcher                   Dispatcher
-	retryHandler                 amboy.RetryHandler
-	staleRetryingMonitorInterval time.Duration
-	lifetimeCtx                  context.Context
+	pending      chan amboy.Job
+	started      bool
+	toDelete     []string
+	storage      map[string]amboy.Job
+	scopes       ScopeManager
+	dispatcher   Dispatcher
+	retryHandler amboy.RetryHandler
+	opts         LocalLimitedSizeSerializableOptions
+	lifetimeCtx  context.Context
 
 	retryingCount int
 	deletedCount  int
@@ -46,20 +45,55 @@ type limitedSizeSerializableLocal struct {
 	mu            sync.RWMutex
 }
 
+// LocalLimitedSizeSerializableOptions provides options to configure and
+// initialize a limited-size local amboy.RetryableQueue.
+type LocalLimitedSizeSerializableOptions struct {
+	NumWorkers int
+	Capacity   int
+	Retryable  RetryableQueueOptions
+}
+
+// Validate checks that the options are valid.
+func (opts *LocalLimitedSizeSerializableOptions) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(opts.NumWorkers <= 0, "number of workers must be a positive number")
+	catcher.NewWhen(opts.Capacity <= 0, "capacity be a positive number")
+	catcher.Wrap(opts.Retryable.Validate(), "invalid retryable queue options")
+	return catcher.Resolve()
+}
+
 // NewLocalLimitedSizeSerializable constructs a local limited-size retryable
 // queue instance with the specified number of workers and maximum capacity.
-func NewLocalLimitedSizeSerializable(workers, capacity int) amboy.RetryableQueue {
+func NewLocalLimitedSizeSerializable(workers, capacity int) (amboy.RetryableQueue, error) {
+	return NewLocalLimitedSizeSerializableWithOptions(LocalLimitedSizeSerializableOptions{
+		NumWorkers: workers,
+		Capacity:   capacity,
+	})
+}
+
+// NewLocalLimitedSizeSerializableWithOptions constructs a local limited-size
+// retryable queue instance with the given options.
+func NewLocalLimitedSizeSerializableWithOptions(opts LocalLimitedSizeSerializableOptions) (amboy.RetryableQueue, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
+	}
 	q := &limitedSizeSerializableLocal{
-		capacity: capacity,
+		opts:     opts,
 		storage:  make(map[string]amboy.Job),
 		scopes:   NewLocalScopeManager(),
 		id:       fmt.Sprintf("queue.local.unordered.fixed.serializable.%s", uuid.New().String()),
-		pending:  make(chan amboy.Job, capacity),
-		toDelete: make([]string, 0, capacity),
+		pending:  make(chan amboy.Job, opts.Capacity),
+		toDelete: make([]string, 0, opts.Capacity),
 	}
+	rh, err := NewBasicRetryHandler(q, opts.Retryable.RetryHandler)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing retry handler")
+	}
+	q.retryHandler = rh
 	q.dispatcher = NewDispatcher(q)
-	q.runner = pool.NewLocalWorkers(workers, q)
-	return q
+	q.runner = pool.NewLocalWorkers(opts.NumWorkers, q)
+
+	return q, nil
 }
 
 // ID returns the ID of this queue instance.
@@ -251,7 +285,7 @@ func (q *limitedSizeSerializableLocal) GetAllAttempts(ctx context.Context, id st
 func (q *limitedSizeSerializableLocal) Next(ctx context.Context) amboy.Job {
 	misses := 0
 	for {
-		if misses > q.capacity {
+		if misses > q.opts.Capacity {
 			return nil
 		}
 
@@ -373,8 +407,8 @@ func (q *limitedSizeSerializableLocal) Runner() amboy.Runner {
 	return q.runner
 }
 
-// SetRunner allows callers to, if the queue has not started, inject a
-// different runner implementation.
+// SetRunner allows callers to inject a different runner implementation if the
+// queue has not yet started.
 func (q *limitedSizeSerializableLocal) SetRunner(r amboy.Runner) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -388,6 +422,7 @@ func (q *limitedSizeSerializableLocal) SetRunner(r amboy.Runner) error {
 	return nil
 }
 
+// RetryHandler returns the queue's retry handler.
 func (q *limitedSizeSerializableLocal) RetryHandler() amboy.RetryHandler {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -395,6 +430,8 @@ func (q *limitedSizeSerializableLocal) RetryHandler() amboy.RetryHandler {
 	return q.retryHandler
 }
 
+// SetRetryHandler allows callers to inject a different retry handler
+// implementation if the queue has not yet started.
 func (q *limitedSizeSerializableLocal) SetRetryHandler(rh amboy.RetryHandler) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -409,13 +446,6 @@ func (q *limitedSizeSerializableLocal) SetRetryHandler(rh amboy.RetryHandler) er
 	q.retryHandler = rh
 
 	return nil
-}
-
-func (q *limitedSizeSerializableLocal) SetStaleRetryingMonitorInterval(interval time.Duration) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	q.staleRetryingMonitorInterval = interval
 }
 
 // Stats returns information about the current state of jobs in the
@@ -492,7 +522,7 @@ func (q *limitedSizeSerializableLocal) prepareComplete(j amboy.Job) {
 }
 
 func (q *limitedSizeSerializableLocal) prepareToDelete(j amboy.Job) {
-	if len(q.toDelete) != 0 && len(q.toDelete) == q.capacity-1 {
+	if len(q.toDelete) != 0 && len(q.toDelete) == q.opts.Capacity-1 {
 		delete(q.storage, q.toDelete[0])
 		q.toDelete = q.toDelete[1:]
 		q.deletedCount++
@@ -659,8 +689,8 @@ func (q *limitedSizeSerializableLocal) monitorStaleRetryingJobs(ctx context.Cont
 	}()
 
 	monitorInterval := defaultStaleRetryingMonitorInterval
-	if q.staleRetryingMonitorInterval != 0 {
-		monitorInterval = q.staleRetryingMonitorInterval
+	if interval := q.opts.Retryable.StaleRetryingMonitorInterval; interval != 0 {
+		monitorInterval = interval
 	}
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -669,6 +699,10 @@ func (q *limitedSizeSerializableLocal) monitorStaleRetryingJobs(ctx context.Cont
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+			if q.opts.Retryable.Disabled() {
+				timer.Reset(monitorInterval)
+				continue
+			}
 			q.handleStaleRetryingJobs(ctx)
 			timer.Reset(monitorInterval)
 		}
@@ -679,6 +713,9 @@ func (q *limitedSizeSerializableLocal) handleStaleRetryingJobs(ctx context.Conte
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	for _, j := range q.storage {
+		if q.opts.Retryable.Disabled() {
+			return
+		}
 		if !j.RetryInfo().ShouldRetry() {
 			continue
 		}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -130,8 +130,8 @@ func DefaultQueueTestCases() []QueueTestCase {
 			ScopesSupported:         true,
 			RetrySupported:          true,
 			Constructor: func(ctx context.Context, _ string, size int) (amboy.Queue, TestCloser, error) {
-				q := NewLocalLimitedSizeSerializable(size, 1024*size)
-				return q, func(ctx context.Context) error { return nil }, nil
+				q, err := NewLocalLimitedSizeSerializable(size, 1024*size)
+				return q, func(ctx context.Context) error { return nil }, err
 			},
 		},
 		{
@@ -1277,13 +1277,9 @@ func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 
 			require.NoError(t, runner.SetPool(rq, size.Size))
 
-			rh, err := NewBasicRetryHandler(rq, amboy.RetryHandlerOptions{})
-			require.NoError(t, err)
-			require.NoError(t, rq.SetRetryHandler(rh))
-
 			require.NoError(t, rq.Start(ctx))
 
-			testCase(ctx, t, rh, rq)
+			testCase(ctx, t, rq.RetryHandler(), rq)
 		})
 	}
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1245,7 +1245,7 @@ func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 
 			select {
 			case <-ctx.Done():
-				require.FailNow(t, ctx.Err().Error())
+				require.FailNow(t, "context was done before stale retrying job could be handled")
 			case <-jobsDone:
 				assert.Equal(t, 2, rq.Stats(ctx).Total)
 				assert.Equal(t, 2, rq.Stats(ctx).Completed)

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -385,7 +385,8 @@ func (q *remoteBase) RetryHandler() amboy.RetryHandler {
 }
 
 // SetRetryHandler allows callers to inject alternative amboy.RetryHandler
-// instances. If this is unset, the queue will not support retrying jobs.
+// instances if the queue has not yet started or if the queue is started but
+// does not already have a retry handler.
 func (q *remoteBase) SetRetryHandler(rh amboy.RetryHandler) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -28,27 +28,49 @@ type remoteQueue interface {
 }
 
 type remoteBase struct {
-	id                           string
-	started                      bool
-	driver                       remoteQueueDriver
-	dispatcher                   Dispatcher
-	driverType                   string
-	channel                      chan amboy.Job
-	blocked                      map[string]struct{}
-	dispatched                   map[string]struct{}
-	runner                       amboy.Runner
-	retryHandler                 amboy.RetryHandler
-	staleRetryingMonitorInterval time.Duration
-	mutex                        sync.RWMutex
+	id           string
+	opts         remoteOptions
+	started      bool
+	driver       remoteQueueDriver
+	dispatcher   Dispatcher
+	driverType   string
+	channel      chan amboy.Job
+	blocked      map[string]struct{}
+	dispatched   map[string]struct{}
+	runner       amboy.Runner
+	retryHandler amboy.RetryHandler
+	mutex        sync.RWMutex
 }
 
-func newRemoteBase() *remoteBase {
-	return &remoteBase{
+type remoteOptions struct {
+	numWorkers int
+	retryable  RetryableQueueOptions
+}
+
+func (opts *remoteOptions) validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(opts.numWorkers <= 0, "number of workers must be a positive number")
+	catcher.Wrap(opts.retryable.Validate(), "invalid retryable queue options")
+	return catcher.Resolve()
+}
+
+func newRemoteBaseWithOptions(opts remoteOptions) (*remoteBase, error) {
+	if err := opts.validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
+	}
+	b := &remoteBase{
 		id:         uuid.New().String(),
 		channel:    make(chan amboy.Job),
 		blocked:    make(map[string]struct{}),
 		dispatched: make(map[string]struct{}),
+		opts:       opts,
 	}
+	rh, err := NewBasicRetryHandler(b, opts.retryable.RetryHandler)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing retry handler")
+	}
+	b.retryHandler = rh
+	return b, nil
 }
 
 func (q *remoteBase) ID() string {
@@ -380,16 +402,6 @@ func (q *remoteBase) SetRetryHandler(rh amboy.RetryHandler) error {
 	return nil
 }
 
-// SetStaleRetryingMonitorInterval configures how frequently the queue will
-// check for stale retrying jobs. If this is unspecified, the default is 1
-// second.
-func (q *remoteBase) SetStaleRetryingMonitorInterval(interval time.Duration) {
-	q.mutex.Lock()
-	defer q.mutex.Unlock()
-
-	q.staleRetryingMonitorInterval = interval
-}
-
 // Driver provides access to the embedded driver instance which
 // provides access to the Queue's persistence layer. This method is
 // not part of the amboy.Queue interface.
@@ -511,8 +523,8 @@ func (q *remoteBase) monitorStaleRetryingJobs(ctx context.Context) {
 	}()
 
 	monitorInterval := defaultStaleRetryingMonitorInterval
-	if q.staleRetryingMonitorInterval != 0 {
-		monitorInterval = q.staleRetryingMonitorInterval
+	if interval := q.opts.retryable.StaleRetryingMonitorInterval; interval != 0 {
+		monitorInterval = interval
 	}
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -521,7 +533,15 @@ func (q *remoteBase) monitorStaleRetryingJobs(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+			if q.opts.retryable.Disabled() {
+				continue
+			}
+
 			for j := range q.driver.RetryableJobs(ctx, retryableJobStaleRetrying) {
+				if q.opts.retryable.Disabled() {
+					break
+				}
+
 				grip.Error(message.WrapError(q.retryHandler.Put(ctx, j), message.Fields{
 					"message":  "could not enqueue stale retrying job",
 					"service":  "amboy.queue.mdb",

--- a/queue/remote_ordered_test.go
+++ b/queue/remote_ordered_test.go
@@ -68,7 +68,7 @@ func (s *SimpleRemoteOrderedSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.canceler = canceler
 	s.NoError(s.driver.Open(ctx))
-	queue, err := newSimpleRemoteOrdered(2)
+	queue, err := newRemoteSimpleOrdered(2)
 	s.Require().NoError(err)
 	s.Require().NoError(queue.SetDriver(s.driver))
 	s.queue = queue

--- a/queue/remote_unordered.go
+++ b/queue/remote_unordered.go
@@ -22,7 +22,8 @@ func newRemoteUnordered(size int) (remoteQueue, error) {
 	return newRemoteUnorderedWithOptions(remoteOptions{numWorkers: size})
 }
 
-// newRemoteUnorderedWithOptions
+// newRemoteUnorderedWithOptions returns a queue that has been initialized with
+// a configured runner and the given options.
 func newRemoteUnorderedWithOptions(opts remoteOptions) (remoteQueue, error) {
 	b, err := newRemoteBaseWithOptions(opts)
 	if err != nil {

--- a/queue/remote_unordered.go
+++ b/queue/remote_unordered.go
@@ -9,25 +9,31 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RemoteUnordered are queues that use a Driver as backend for job
-// storage and processing and do not impose any additional ordering
-// beyond what's provided by the driver.
+// remoteUnordered implements the amboy.RetryableQueue interface. It uses a
+// Driver to access a backend for job storage and processing. The queue does not
+// impose any additional job ordering beyond what's provided by the driver.
 type remoteUnordered struct {
 	*remoteBase
 }
 
 // newRemoteUnordered returns a queue that has been initialized with a
-// local worker pool Runner instance of the specified size.
+// configured local worker pool with the specified number of workers.
 func newRemoteUnordered(size int) (remoteQueue, error) {
-	q := &remoteUnordered{
-		remoteBase: newRemoteBase(),
-	}
+	return newRemoteUnorderedWithOptions(remoteOptions{numWorkers: size})
+}
 
+// newRemoteUnorderedWithOptions
+func newRemoteUnorderedWithOptions(opts remoteOptions) (remoteQueue, error) {
+	b, err := newRemoteBaseWithOptions(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing remote base")
+	}
+	q := &remoteUnordered{remoteBase: b}
 	q.dispatcher = NewDispatcher(q)
-	if err := q.SetRunner(pool.NewLocalWorkers(size, q)); err != nil {
+	if err := q.SetRunner(pool.NewLocalWorkers(opts.numWorkers, q)); err != nil {
 		return nil, errors.Wrap(err, "configuring runner")
 	}
-	grip.Infof("creating new remote job queue with %d workers", size)
+	grip.Infof("creating new remote job queue with %d workers", opts.numWorkers)
 
 	return q, nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14027

* Add feature flag to dynamically disable retryability at runtime.
* Group retryable queue options into common options struct.
* Provide a way to initialize retryable queues with the retry handler in their constructors rather than setting it after construction.
* Tidy up the makefile a bit.