### PR TITLE
EVG-14302: return errors from queue complete method

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -307,7 +307,7 @@ type Queue interface {
 	Info() QueueInfo
 
 	// Complete marks a Job as completed executing.
-	Complete(context.Context, Job)
+	Complete(context.Context, Job) error
 
 	// Save persists the state of a current Job to the underlying storage,
 	// generally in support of locking and incremental persistence.
@@ -520,5 +520,5 @@ type AbortableRunner interface {
 	IsRunning(string) bool
 	RunningJobs() []string
 	Abort(context.Context, string) error
-	AbortAll(context.Context)
+	AbortAll(context.Context) error
 }

--- a/management/queue.go
+++ b/management/queue.go
@@ -381,7 +381,9 @@ func (m *queueManager) CompleteJobsByType(ctx context.Context, f StatusFilter, j
 }
 
 func (m *queueManager) completeJob(ctx context.Context, j amboy.Job) error {
-	m.queue.Complete(ctx, j)
+	if err := m.queue.Complete(ctx, j); err != nil {
+		return errors.Wrap(err, "completing job")
+	}
 
 	var err error
 	amboy.WithRetryableQueue(m.queue, func(rq amboy.RetryableQueue) {

--- a/pool/abortable_test.go
+++ b/pool/abortable_test.go
@@ -170,7 +170,7 @@ func (s *AbortablePoolSuite) TestAbortAllWorks() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.pool.AbortAll(ctx)
+	s.Require().NoError(s.pool.AbortAll(ctx))
 	s.Len(s.pool.RunningJobs(), 0)
 	seen = 0
 	for _, c := range closers {

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -35,7 +35,7 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 	j.Run(jobCtx)
 	if err := q.Complete(ctx, j); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
-			"message":  "could not mark job as complete",
+			"message":  "could not mark job complete",
 			"job_id":   j.ID(),
 			"queue_id": q.ID(),
 		}))
@@ -110,7 +110,7 @@ func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup, 
 				job.AddError(err)
 				if err := q.Complete(ctx, job); err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
-						"message":     "could not mark job as complete",
+						"message":     "could not mark job complete",
 						"job_id":      job.ID(),
 						"queue_id":    q.ID(),
 						"panic_error": err,

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -91,11 +91,13 @@ func (q *QueueTester) info() amboy.QueueInfo {
 	}
 }
 
-func (q *QueueTester) Complete(ctx context.Context, j amboy.Job) {
+func (q *QueueTester) Complete(ctx context.Context, j amboy.Job) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
 	q.numComplete++
+
+	return nil
 }
 
 func (q *QueueTester) Stats(ctx context.Context) amboy.QueueStats {

--- a/pool/rate_limiting.go
+++ b/pool/rate_limiting.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 )
 
@@ -112,7 +113,11 @@ func (p *simpleRateLimited) worker(bctx context.Context) {
 		if err != nil {
 			if job != nil {
 				job.AddError(err)
-				p.queue.Complete(bctx, job)
+				grip.Error(message.WrapError(p.queue.Complete(bctx, job), message.Fields{
+					"message":  "could not mark job complete",
+					"job_id":   job.ID(),
+					"queue_id": p.queue.ID(),
+				}))
 			}
 			// start a replacement worker.
 			go p.worker(bctx)

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -96,7 +96,6 @@ func TestDriverSuiteWithMongoDBInstance(t *testing.T) {
 
 func (s *DriverSuite) SetupSuite() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	job.RegisterDefaultJobs()
 }
 
 func (s *DriverSuite) SetupTest() {

--- a/queue/mock_test.go
+++ b/queue/mock_test.go
@@ -43,7 +43,7 @@ type mockRemoteQueue struct {
 	saveJob                   func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	completeRetryingAndPutJob func(ctx context.Context, q remoteQueue, toComplete, toPut amboy.Job) error
 	nextJob                   func(ctx context.Context, q remoteQueue) amboy.Job
-	completeJob               func(ctx context.Context, q remoteQueue, j amboy.Job)
+	completeJob               func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	completeRetryingJob       func(ctx context.Context, q remoteQueue, j amboy.Job) error
 	jobResults                func(ctx context.Context, q remoteQueue) <-chan amboy.Job
 	jobInfo                   func(ctx context.Context, q remoteQueue) <-chan amboy.JobInfo
@@ -168,12 +168,11 @@ func (q *mockRemoteQueue) Next(ctx context.Context) amboy.Job {
 	return q.remoteQueue.Next(ctx)
 }
 
-func (q *mockRemoteQueue) Complete(ctx context.Context, j amboy.Job) {
+func (q *mockRemoteQueue) Complete(ctx context.Context, j amboy.Job) error {
 	if q.completeJob != nil {
-		q.completeJob(ctx, q.remoteQueue, j)
-		return
+		return q.completeJob(ctx, q.remoteQueue, j)
 	}
-	q.remoteQueue.Complete(ctx, j)
+	return q.remoteQueue.Complete(ctx, j)
 }
 
 func (q *mockRemoteQueue) CompleteRetrying(ctx context.Context, j amboy.Job) error {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -568,7 +568,7 @@ func TestQueueSmoke(t *testing.T) {
 								require.True(t, ok)
 
 								require.NoError(t, j.Error())
-								q.Complete(ctx, j)
+								require.NoError(t, q.Complete(ctx, j))
 								require.NoError(t, j.Error())
 							})
 						})

--- a/queue/remote_unordered_test.go
+++ b/queue/remote_unordered_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func init() {
-	job.RegisterDefaultJobs()
-}
-
 type RemoteUnorderedSuite struct {
 	queue             *remoteUnordered
 	driver            remoteQueueDriver

--- a/queue/shuffled_test.go
+++ b/queue/shuffled_test.go
@@ -158,7 +158,7 @@ func (s *ShuffledQueueSuite) TestCompleteReturnsIfContextisCanceled() {
 	ctx2, cancel2 := context.WithCancel(ctx)
 	j := job.NewShellJob("false", "")
 	cancel2()
-	s.queue.Complete(ctx2, j)
+	s.Require().Error(s.queue.Complete(ctx2, j))
 	stat := s.queue.Stats(ctx)
 	s.Equal(0, stat.Completed)
 }

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mongodb/amboy/pool"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
@@ -209,28 +208,22 @@ func (q *sqsFIFOQueue) Info() amboy.QueueInfo {
 
 // Used to mark a Job complete and remove it from the pending
 // work of the queue.
-func (q *sqsFIFOQueue) Complete(ctx context.Context, job amboy.Job) {
+func (q *sqsFIFOQueue) Complete(ctx context.Context, job amboy.Job) error {
 	if ctx.Err() != nil {
-		return
+		return ctx.Err()
 	}
 	name := job.ID()
 	q.dispatcher.Complete(ctx, job)
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
-	if ctx.Err() != nil {
-		grip.Notice(message.Fields{
-			"message":   "Did not complete job because context cancelled",
-			"id":        name,
-			"operation": "Complete",
-		})
-		return
-	}
 	q.tasks.completed[name] = true
 	savedJob := q.tasks.all[name]
 	if savedJob != nil {
 		savedJob.SetStatus(job.Status())
 		savedJob.UpdateTimeInfo(job.TimeInfo())
 	}
+
+	return nil
 }
 
 // Returns a channel that produces completed Job objects.

--- a/queue/sqs_test.go
+++ b/queue/sqs_test.go
@@ -86,8 +86,8 @@ func (s *SQSFifoQueueSuite) TestCompleteMethodChangesStatsAndResults() {
 	defer cancel()
 
 	j := job.NewShellJob("echo true", "")
-	s.NoError(s.queue.Put(ctx, j))
-	s.queue.Complete(context.Background(), j)
+	s.Require().NoError(s.queue.Put(ctx, j))
+	s.Require().NoError(s.queue.Complete(context.Background(), j))
 
 	counter := 0
 	results := s.queue.Results(context.Background())

--- a/rest/service_abortable_pool.go
+++ b/rest/service_abortable_pool.go
@@ -50,10 +50,12 @@ func (s *AbortablePoolManagementService) ListJobs(rw http.ResponseWriter, r *htt
 func (s *AbortablePoolManagementService) AbortAllJobs(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	s.pool.AbortAll(ctx)
-
-	if ctx.Err() != nil {
-		gimlet.WriteJSONResponse(rw, http.StatusRequestTimeout, struct{}{})
+	if err := s.pool.AbortAll(ctx); err != nil {
+		if ctx.Err() != nil {
+			gimlet.WriteJSONResponse(rw, http.StatusRequestTimeout, struct{}{})
+			return
+		}
+		gimlet.WriteJSONInternalError(rw, err.Error())
 		return
 	}
 

--- a/rest/service_queue_test.go
+++ b/rest/service_queue_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
@@ -21,8 +20,6 @@ func init() {
 	lvl := grip.GetSender().Level()
 	lvl.Threshold = level.Warning
 	_ = grip.GetSender().SetLevel(lvl)
-
-	job.RegisterDefaultJobs()
 }
 
 type RestServiceSuite struct {
@@ -36,9 +33,6 @@ func TestRestServiceSuite(t *testing.T) {
 }
 
 func (s *RestServiceSuite) SetupSuite() {
-	// need to import job so that we load the init functions that
-	// register jobs so these tests are more meaningful.
-	job.RegisterDefaultJobs()
 	s.require = s.Require()
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14302

* Return errors from `(Queue).Complete`.
* Fix some small bugs in queue implementations around logging and ignoring errors during `(Queue).Complete`.