### PR TITLE
EVG-14293: do not report negative job runtime if context is done

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -39,6 +39,11 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 			"job_id":   j.ID(),
 			"queue_id": q.ID(),
 		}))
+		// If the job cannot not marked as complete in the queue, set the end
+		// time so that the calculated job execution statistics are valid.
+		j.UpdateTimeInfo(amboy.JobTimeInfo{
+			End: time.Now(),
+		})
 	}
 
 	amboy.WithRetryableQueue(q, func(rq amboy.RetryableQueue) {

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -233,10 +233,8 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) error {
 			stat.InProgress = false
 			j.SetStatus(stat)
 
-			ti := j.TimeInfo()
 			j.UpdateTimeInfo(amboy.JobTimeInfo{
-				Start: ti.Start,
-				End:   time.Now(),
+				End: time.Now(),
 			})
 
 			err = q.driver.Complete(ctx, j)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14293

* Set the end time if the queue doesn't do it in `(Queue).Complete`.
* Don't unnecessarily update the job start time when the remote queue completes a job.