### PR TITLE
EVG-14320: fix small bugs from end to end test

### DIFF
--- a/job/base.go
+++ b/job/base.go
@@ -135,7 +135,6 @@ func (b *Base) Lock(id string, lockTimeout time.Duration) error {
 	if b.status.Completed && b.retryInfo.NeedsRetry && time.Since(b.status.ModificationTime) < lockTimeout && b.status.Owner != id {
 		return errors.Errorf("cannot take retry lock for '%s' because lock has been held for %s by %s", id, time.Since(b.status.ModificationTime), b.status.Owner)
 	}
-	b.status.InProgress = true
 	b.status.Owner = id
 	b.status.ModificationTime = time.Now()
 	b.status.ModificationCount++

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -76,6 +76,10 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, job amboy.Job) error {
 	}
 	job.UpdateTimeInfo(ti)
 
+	status := job.Status()
+	status.InProgress = true
+	job.SetStatus(status)
+
 	info := dispatcherInfo{
 		job: job,
 	}
@@ -145,6 +149,10 @@ func pingJobLock(ctx context.Context, pingCtx context.Context, q amboy.Queue, j 
 		case <-pingCtx.Done():
 			return
 		case <-ticker.C:
+			status := j.Status()
+			status.InProgress = true
+			j.SetStatus(status)
+
 			if err := j.Lock(q.ID(), q.Info().LockTimeout); err != nil {
 				j.AddError(errors.Wrapf(err, "problem pinging job lock on cycle #%d", iters))
 				grip.Debug(message.WrapError(err, message.Fields{

--- a/queue/dispatcher_test.go
+++ b/queue/dispatcher_test.go
@@ -52,6 +52,10 @@ func (d *mockDispatcher) Dispatch(ctx context.Context, j amboy.Job) error {
 	}
 	j.UpdateTimeInfo(ti)
 
+	status := j.Status()
+	status.InProgress = true
+	j.SetStatus(status)
+
 	if d.initialLock != nil {
 		if err := d.initialLock(j); err != nil {
 			return errors.Wrap(err, "taking initial lock on job")

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -597,6 +597,9 @@ func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	j := job.NewShellJob("echo foo", "")
+	j.SetStatus(amboy.JobStatusInfo{
+		InProgress: true,
+	})
 	s.Require().NoError(j.Lock("taken", amboy.LockTimeout))
 
 	s.NoError(s.driver.Put(s.ctx, j))

--- a/queue/remote_unordered_test.go
+++ b/queue/remote_unordered_test.go
@@ -245,6 +245,9 @@ func (s *RemoteUnorderedSuite) TestNextMethodSkipsLockedJobs() {
 
 		if i%3 == 0 {
 			numLocked++
+			j.SetStatus(amboy.JobStatusInfo{
+				InProgress: true,
+			})
 			err := j.Lock(s.driver.ID(), amboy.LockTimeout)
 			s.NoError(err)
 

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -437,8 +437,8 @@ func (rh *BasicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Job) (ca
 		if !newInfo.ShouldRetry() {
 			return false, errors.New("job in the queue indicates the job does not need to retry anymore")
 		}
-		if originalInfo.CurrentAttempt+1 > newInfo.GetMaxAttempts() {
-			return false, errors.New("job has exceeded its maximum attempt limit")
+		if originalInfo.CurrentAttempt+1 >= newInfo.GetMaxAttempts() {
+			return false, errors.New("job has reached its maximum attempt limit")
 		}
 
 		lockTimeout := rh.queue.Info().LockTimeout

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -315,7 +315,7 @@ func (rh *BasicRetryHandler) waitForJob(ctx context.Context) {
 				"job_attempt": j.RetryInfo().CurrentAttempt,
 				"num_pending": len(rh.pending) + len(rh.pendingOverflow),
 				"queue_id":    rh.queue.ID(),
-				"duration":    time.Since(startAt),
+				"duration":    time.Since(startAt).String(),
 				"service":     "amboy.queue.retry",
 			})
 			rh.mu.RUnlock()
@@ -375,7 +375,7 @@ func (rh *BasicRetryHandler) handleJob(ctx context.Context, j amboy.Job) error {
 	})
 	for i := 1; i <= rh.opts.MaxRetryAttempts; i++ {
 		if rh.opts.Disabled() {
-			catcher.Errorf("giving up after %s (%d attempts) due to retries being disabled", startAt.String(), i-1)
+			catcher.Errorf("giving up after %s (%d attempts) due to retries being disabled", time.Since(startAt).String(), i-1)
 			return catcher.Resolve()
 		}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14320

* Fix a bug where lock/save would set the retrying job to in progress.
* Fix an off-by-one in comparing job's max attempts against its current attempt.
* Fix some small errors in time duration logging.