### PR TITLE
EVG-14519: reduce logging level for Complete errors

### DIFF
--- a/pool/abortable.go
+++ b/pool/abortable.go
@@ -135,7 +135,7 @@ func (p *abortablePool) worker(bctx context.Context) {
 		if err != nil {
 			if job != nil {
 				job.AddError(err)
-				grip.Error(message.WrapError(p.queue.Complete(bctx, job), message.Fields{
+				grip.Warning(message.WrapError(p.queue.Complete(bctx, job), message.Fields{
 					"message":  "could not mark job complete",
 					"job_id":   job.ID(),
 					"queue_id": p.queue.ID(),

--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -34,7 +34,7 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 	}
 	j.Run(jobCtx)
 	if err := q.Complete(ctx, j); err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
+		grip.Warning(message.WrapError(err, message.Fields{
 			"message":  "could not mark job complete",
 			"job_id":   j.ID(),
 			"queue_id": q.ID(),
@@ -114,7 +114,7 @@ func worker(bctx context.Context, id string, q amboy.Queue, wg *sync.WaitGroup, 
 			if job != nil {
 				job.AddError(err)
 				if err := q.Complete(ctx, job); err != nil {
-					grip.Error(message.WrapError(err, message.Fields{
+					grip.Warning(message.WrapError(err, message.Fields{
 						"message":     "could not mark job complete",
 						"job_id":      job.ID(),
 						"queue_id":    q.ID(),

--- a/pool/rate_limiting.go
+++ b/pool/rate_limiting.go
@@ -113,7 +113,7 @@ func (p *simpleRateLimited) worker(bctx context.Context) {
 		if err != nil {
 			if job != nil {
 				job.AddError(err)
-				grip.Error(message.WrapError(p.queue.Complete(bctx, job), message.Fields{
+				grip.Warning(message.WrapError(p.queue.Complete(bctx, job), message.Fields{
 					"message":  "could not mark job complete",
 					"job_id":   job.ID(),
 					"queue_id": p.queue.ID(),

--- a/queue/dispatcher_test.go
+++ b/queue/dispatcher_test.go
@@ -193,7 +193,7 @@ func TestDispatcherImplementations(t *testing.T) {
 					assert.NotZero(t, oldStatus.ModificationTime)
 					assert.True(t, oldStatus.InProgress)
 
-					time.Sleep(lockTimeout)
+					time.Sleep(2 * lockTimeout)
 
 					newStatus := j.Status()
 					assert.True(t, oldStatus.ModificationTime.Before(newStatus.ModificationTime))
@@ -216,7 +216,7 @@ func TestDispatcherImplementations(t *testing.T) {
 					assert.NotZero(t, oldStatus.ModificationTime)
 					assert.True(t, oldStatus.InProgress)
 
-					time.Sleep(lockTimeout)
+					time.Sleep(2 * lockTimeout)
 
 					newStatus := j.Status()
 					assert.Equal(t, oldStatus.ModificationTime, newStatus.ModificationTime)
@@ -238,7 +238,7 @@ func TestDispatcherImplementations(t *testing.T) {
 					assert.NotZero(t, oldStatus.ModificationTime)
 					assert.True(t, oldStatus.InProgress)
 
-					time.Sleep(lockTimeout)
+					time.Sleep(2 * lockTimeout)
 
 					newStatus := j.Status()
 					assert.True(t, oldStatus.ModificationTime.Before(newStatus.ModificationTime))
@@ -259,7 +259,7 @@ func TestDispatcherImplementations(t *testing.T) {
 					assert.NotZero(t, oldStatus.ModificationTime)
 					assert.True(t, oldStatus.InProgress)
 
-					time.Sleep(lockTimeout)
+					time.Sleep(2 * lockTimeout)
 
 					newStatus := j.Status()
 					assert.Equal(t, oldStatus.ModificationTime, newStatus.ModificationTime)
@@ -281,7 +281,7 @@ func TestDispatcherImplementations(t *testing.T) {
 
 					d.Complete(ctx, j)
 
-					time.Sleep(lockTimeout)
+					time.Sleep(2 * lockTimeout)
 
 					newStatus := j.Status()
 					assert.Equal(t, oldStatus.ModificationTime, newStatus.ModificationTime)

--- a/queue/ordered.go
+++ b/queue/ordered.go
@@ -355,7 +355,7 @@ func (q *depGraphOrderedLocal) jobDispatch(ctx context.Context, orderedJobs []gr
 		q.mutex.Unlock()
 
 		if job.Dependency().State() == dependency.Passed {
-			grip.Error(message.WrapError(q.Complete(ctx, job), message.Fields{
+			grip.Warning(message.WrapError(q.Complete(ctx, job), message.Fields{
 				"message":  "could not mark job complete",
 				"job_id":   job.ID(),
 				"queue_id": q.ID(),
@@ -406,7 +406,7 @@ func (q *depGraphOrderedLocal) jobDispatch(ctx context.Context, orderedJobs []gr
 				// all dependencies have passed, we can try to dispatch the job.
 
 				if job.Dependency().State() == dependency.Passed {
-					grip.Error(message.WrapError(q.Complete(ctx, job), message.Fields{
+					grip.Warning(message.WrapError(q.Complete(ctx, job), message.Fields{
 						"message":  "could not mark job complete",
 						"job_id":   job.ID(),
 						"queue_id": q.ID(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14519

Reduce log level to warning. I noticed that in evergreen staging, it would log for long-running jobs that failed to complete within the grace period for the app server shutdown, which was noisy when the apps were deployed/restarted. Since jobs  should re-run when they fail to get marked complete, it should be fine to reduce the log level.