### PR TITLE
EVG-14558: break stats aggregation into separate queries for queue group

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1362,6 +1362,7 @@ type driverQueueStats struct {
 	retrying   int
 }
 
+// getStats returns the job statistics for a remote MongoDB queue.
 func (d *mongoDriver) getStats(ctx context.Context) driverQueueStats {
 	coll := d.getCollection()
 
@@ -1440,6 +1441,7 @@ func (d *mongoDriver) getStats(ctx context.Context) driverQueueStats {
 	}
 }
 
+// getGroupStats returns the job statistics for a queue group.
 // If we're using queue groups, issue each query separately. The discrepancy
 // between the regular MongoDB queue and the MongoDB queue group is that the
 // server fails to use separate indexes for each clause in $or (EVG-14558).

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -521,19 +521,21 @@ func (s *DriverSuite) TestStatsCallReportsCompletedJobs() {
 
 	s.Equal(0, s.driver.Stats(s.ctx).Total)
 	s.NoError(s.driver.Put(s.ctx, j))
-	s.Equal(1, s.driver.Stats(s.ctx).Total)
-	s.Equal(0, s.driver.Stats(s.ctx).Completed)
-	s.Equal(1, s.driver.Stats(s.ctx).Pending)
-	s.Equal(0, s.driver.Stats(s.ctx).Blocked)
-	s.Equal(0, s.driver.Stats(s.ctx).Running)
+	stats := s.driver.Stats(s.ctx)
+	s.Equal(1, stats.Total)
+	s.Equal(0, stats.Completed)
+	s.Equal(1, stats.Pending)
+	s.Equal(0, stats.Blocked)
+	s.Equal(0, stats.Running)
 
 	j.MarkComplete()
 	s.NoError(s.driver.Save(s.ctx, j))
-	s.Equal(1, s.driver.Stats(s.ctx).Total)
-	s.Equal(1, s.driver.Stats(s.ctx).Completed)
-	s.Equal(0, s.driver.Stats(s.ctx).Pending)
-	s.Equal(0, s.driver.Stats(s.ctx).Blocked)
-	s.Equal(0, s.driver.Stats(s.ctx).Running)
+	stats = s.driver.Stats(s.ctx)
+	s.Equal(1, stats.Total)
+	s.Equal(1, stats.Completed)
+	s.Equal(0, stats.Pending)
+	s.Equal(0, stats.Blocked)
+	s.Equal(0, stats.Running)
 }
 
 func (s *DriverSuite) TestStatsCountsAreAccurate() {
@@ -603,10 +605,11 @@ func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 	s.Require().NoError(j.Lock("taken", amboy.LockTimeout))
 
 	s.NoError(s.driver.Put(s.ctx, j))
-	s.Equal(1, s.driver.Stats(s.ctx).Total)
-	s.Equal(0, s.driver.Stats(s.ctx).Blocked)
-	s.Equal(1, s.driver.Stats(s.ctx).Running)
-	s.Equal(0, s.driver.Stats(s.ctx).Completed)
+	stats := s.driver.Stats(s.ctx)
+	s.Equal(1, stats.Total)
+	s.Equal(0, stats.Blocked)
+	s.Equal(1, stats.Running)
+	s.Equal(0, stats.Completed)
 
 	s.Nil(s.driver.Next(ctx), fmt.Sprintf("%T", s.driver))
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1247,9 +1247,6 @@ func RetryableTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 			case <-ctx.Done():
 				require.FailNow(t, "context was done before stale retrying job could be handled")
 			case <-jobsDone:
-				assert.Equal(t, 2, rq.Stats(ctx).Total)
-				assert.Equal(t, 2, rq.Stats(ctx).Completed)
-
 				rj0, err := rq.GetAttempt(ctx, j.ID(), 0)
 				require.NoError(t, err)
 				assert.True(t, rj0.RetryInfo().Retryable)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14558

The [MongoDB docs](https://docs.mongodb.com/manual/reference/operator/query/or/#-or-clauses-and-indexes) say that `$or` is supposed to be able to use a separate index for each of its clauses. I tested this in staging and it seems to be true for the non-group case, where it correctly used the best index for each of the 3 clauses:

```
$ db.evg.service.jobs.explain().aggregate({"$match": {"$or": [{"status.completed": false, "status.in_prog": false}, {"status.completed": false, "status.in_prog": true}, {"status.completed": true, "retry_info.retryable": true, "retry_info.needs_retry": true}]}})

		"winningPlan" : {
			"stage" : "SUBPLAN",
			"inputStage" : {
				"stage" : "FETCH",
				"inputStage" : {
					"stage" : "OR",
					"inputStages" : [
						{
							"stage" : "IXSCAN",
							"keyPattern" : {
								"status.completed" : 1,
								"status.in_prog" : 1,
								"time_info.wait_until" : 1,
								"priority" : 1
							},
							"indexName" : "status.completed_1_status.in_prog_1_time_info.wait_until_1_priority_1",
							"isMultiKey" : false,
							"multiKeyPaths" : {
								"status.completed" : [ ],
								"status.in_prog" : [ ],
								"time_info.wait_until" : [ ],
								"priority" : [ ]
							},
							"isUnique" : false,
							"isSparse" : false,
							"isPartial" : false,
							"indexVersion" : 2,
							"direction" : "forward",
							"indexBounds" : {
								"status.completed" : [
									"[false, false]"
								],
								"status.in_prog" : [
									"[false, false]"
								],
								"time_info.wait_until" : [
									"[MinKey, MaxKey]"
								],
								"priority" : [
									"[MinKey, MaxKey]"
								]
							}
						},
						{
							"stage" : "IXSCAN",
							"keyPattern" : {
								"status.completed" : 1,
								"status.in_prog" : 1,
								"time_info.wait_until" : 1,
								"priority" : 1
							},
							"indexName" : "status.completed_1_status.in_prog_1_time_info.wait_until_1_priority_1",
							"isMultiKey" : false,
							"multiKeyPaths" : {
								"status.completed" : [ ],
								"status.in_prog" : [ ],
								"time_info.wait_until" : [ ],
								"priority" : [ ]
							},
							"isUnique" : false,
							"isSparse" : false,
							"isPartial" : false,
							"indexVersion" : 2,
							"direction" : "forward",
							"indexBounds" : {
								"status.completed" : [
									"[false, false]"
								],
								"status.in_prog" : [
									"[true, true]"
								],
								"time_info.wait_until" : [
									"[MinKey, MaxKey]"
								],
								"priority" : [
									"[MinKey, MaxKey]"
								]
							}
						},
						{
							"stage" : "IXSCAN",
							"keyPattern" : {
								"status.completed" : NumberLong(1),
								"retry_info.retryable" : NumberLong(1),
								"retry_info.needs_retry" : NumberLong(1),
								"status.mod_ts" : NumberLong(-1)
							},
							"indexName" : "status.completed_1_retry_info.retryable_1_retry_info.needs_retry_1_status.mod_ts_-1",
							"isMultiKey" : false,
							"multiKeyPaths" : {
								"status.completed" : [ ],
								"retry_info.retryable" : [ ],
								"retry_info.needs_retry" : [ ],
								"status.mod_ts" : [ ]
							},
							"isUnique" : false,
							"isSparse" : false,
							"isPartial" : false,
							"indexVersion" : 2,
							"direction" : "forward",
							"indexBounds" : {
								"status.completed" : [
									"[true, true]"
								],
								"retry_info.retryable" : [
									"[true, true]"
								],
								"retry_info.needs_retry" : [
									"[true, true]"
								],
								"status.mod_ts" : [
									"[MaxKey, MinKey]"
								]
							}
						}
					]
				}
			}
		},
```

However, if you add the `"group"` to the query, it doesn't use the group indexes and instead issues the query without `"group"` for some reason:

```
$ db.evg.service.group.explain().aggregate({"$match": {"$or": [{"group": "some_group", "status.completed": false, "status.in_prog": false}, {"group": "some_group", "status.completed": false, "status.in_prog": true}, {"group": "some_group", "status.completed": true, "retry_info.retryable": true, "retry_info.needs_retry": true}]}})

		"winningPlan" : {
			"stage" : "FETCH",
			"filter" : {
				"$or" : [
					{
						"$and" : [
							{
								"retry_info.needs_retry" : {
									"$eq" : true
								}
							},
							{
								"retry_info.retryable" : {
									"$eq" : true
								}
							},
							{
								"status.completed" : {
									"$eq" : true
								}
							}
						]
					},
					{
						"$and" : [
							{
								"status.completed" : {
									"$eq" : false
								}
							},
							{
								"status.in_prog" : {
									"$eq" : false
								}
							}
						]
					},
					{
						"$and" : [
							{
								"status.completed" : {
									"$eq" : false
								}
							},
							{
								"status.in_prog" : {
									"$eq" : true
								}
							}
						]
					}
				]
			},
			"inputStage" : {
				"stage" : "IXSCAN",
				"keyPattern" : {
					"group" : 1,
					"type" : 1,
					"status.completed" : 1,
					"time_info.end" : 1
				},
				"indexName" : "group_1_type_1_status.completed_1_time_info.end_1",
				"isMultiKey" : false,
				"multiKeyPaths" : {
					"group" : [ ],
					"type" : [ ],
					"status.completed" : [ ],
					"time_info.end" : [ ]
				},
				"isUnique" : false,
				"isSparse" : false,
				"isPartial" : false,
				"indexVersion" : 2,
				"direction" : "forward",
				"indexBounds" : {
					"group" : [
						"[\"some_group\", \"some_group\"]"
					],
					"type" : [
						"[MinKey, MaxKey]"
					],
					"status.completed" : [
						"[MinKey, MaxKey]"
					],
					"time_info.end" : [
						"[MinKey, MaxKey]"
					]
				}
			}
		},
```

It does this even though there are indexes on all 3 separate clauses in `$or`. I guess an alternative way to fix this would be to build indexes on each of the `$or` clauses _without_ including the group so that it utilizes indexes for each query. Let me know if you would prefer the solution of building more non-obvious indexes rather than changing the stats aggregation.

I changed the queue group behavior to just issue separate queries for each clause in `$or` to force it to utilize all 3 indexes (which is probably less correct, but uses the expected indexes). The regular remote MongoDB queue can still use the aggregation because it correctly chooses the optimal winning plan.