### PR TITLE
EVG-14609: prevent jobs from being both in progress and completed

### DIFF
--- a/job/base.go
+++ b/job/base.go
@@ -58,6 +58,7 @@ func (b *Base) MarkComplete() {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
+	b.status.InProgress = false
 	b.status.Completed = true
 }
 

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -213,6 +213,7 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 		case <-ticker.C:
 			status := j.Status()
 			status.InProgress = true
+			status.Completed = false
 			j.SetStatus(status)
 
 			if err := j.Lock(q.ID(), q.Info().LockTimeout); err != nil {

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -597,30 +597,42 @@ func (d *mongoDriver) Put(ctx context.Context, j amboy.Job) error {
 	return nil
 }
 
-func (d *mongoDriver) getAtomicQuery(jobName string, modCount int) bson.M {
+func (d *mongoDriver) getAtomicQuery(jobName string, stat amboy.JobStatusInfo) bson.M {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	owner := d.instanceID
 	timeoutTs := time.Now().Add(-d.LockTimeout())
 
+	// The lock can be acquired if the modification time is unset (i.e. it's
+	// unowned) or older than the lock timeout (i.e. the lock is stale),
+	// regardless of what the other data is.
+	unownedOrStaleLock := bson.M{"status.mod_ts": bson.M{"$lte": timeoutTs}}
+
+	// The lock is actively owned by this in-memory instance of the queue if
+	// owner and modification count match.
+	//
+	// The modification count is +1 in the case that we're looking to update the
+	// job and its modification count (in the Complete case, it does not update
+	// the modification count).
+	activeOwnedLock := bson.M{
+		"status.owner":     owner,
+		"status.mod_count": bson.M{"$in": []int{stat.ModificationCount, stat.ModificationCount - 1}},
+		"status.mod_ts":    bson.M{"$gt": timeoutTs},
+	}
+
+	// If we're trying to update the status to in progress or maintain that it
+	// is in progress, this is only allowed if the job is not already marked
+	// complete.
+	if stat.InProgress {
+		unownedOrStaleLock["status.completed"] = false
+		activeOwnedLock["status.completed"] = false
+	}
+
 	return bson.M{
 		"_id": jobName,
 		"$or": []bson.M{
-			// owner and modcount should match, which
-			// means there's an active lock but we own it.
-			//
-			// The modcount is +1 in the case that we're
-			// looking to update and update the modcount
-			// (rather than just save, as in the Complete
-			// case).
-			{
-				"status.owner":     owner,
-				"status.mod_count": bson.M{"$in": []int{modCount, modCount - 1}},
-				"status.mod_ts":    bson.M{"$gt": timeoutTs},
-			},
-			// modtime is older than the lock timeout,
-			// regardless of what the other data is,
-			{"status.mod_ts": bson.M{"$lte": timeoutTs}},
+			unownedOrStaleLock,
+			activeOwnedLock,
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14609

I've seen cases in staging and prod where jobs can be both in progress and completed at the same time, often for long-running jobs that have their context cancelled during the deploy. This bug seems to have been around for a long while, since I've seen this in jobs going back to at least January, so maybe it's always been a bug but has only been an issue now because more jobs use scopes. I believe this is because `(Job).MarkComplete` marks a job as complete but doesn't clear in progress and `(remoteQueue).Complete` will exit early and will _not_ do anything if the context is cancelled (i.e. when a deploy is shutting down the app server and the queue runner is closed).

Since it's invalid for a job to be both in progress and completed at the same time, I made it more explicit in all places where in progress/completed is set that the two states are mutually exclusive. I also changed the atomic query to make it impossible to update a job back to in progress once it's completed. As a last extra safety measure, I changed the job update helper `doUpdate` to manually intervene and set in progress to false if complete is already true. I'm going to make a Splunk alert for myself to monitor for that log message in case it recurs, since it's a programmer logic error.