### PR TITLE
EVG-14617: clean up queue resources during close

### DIFF
--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -26,6 +26,9 @@ type Dispatcher interface {
 	// Complete relinquishes the worker's exclusive ownership of the job. It may
 	// optionally update metadata indicating that the job is finished.
 	Complete(context.Context, amboy.Job)
+	// TODO (EVG-14617): add Close method to stop the dispatcher from further
+	// dispatches. It can be called when the queue closes to stop further
+	// dispatching from occurring and giving up on all actively-dispatched jobs.
 }
 
 type dispatcherImpl struct {

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -202,6 +202,12 @@ func (d *dispatcherImpl) Close(ctx context.Context) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
+	if d.closed {
+		return nil
+	}
+
+	d.closed = true
+
 	catcher := grip.NewBasicCatcher()
 	for jobID := range d.cache {
 		info, ok := d.popInfo(jobID)
@@ -210,8 +216,6 @@ func (d *dispatcherImpl) Close(ctx context.Context) error {
 		}
 		catcher.Wrapf(d.waitForPing(ctx, info), "waiting for job ping to complete for job '%s'", jobID)
 	}
-
-	d.closed = true
 
 	return catcher.Resolve()
 }

--- a/queue/dispatcher_test.go
+++ b/queue/dispatcher_test.go
@@ -151,8 +151,9 @@ func (d *mockDispatcher) Close(ctx context.Context) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	catcher := grip.NewBasicCatcher()
 	for jobID := range d.dispatched {
-		d.release(ctx, jobID)
+		catcher.Wrapf(d.release(ctx, jobID), "releasing job '%s'", jobID)
 	}
 
 	d.closed = true

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -13,7 +13,7 @@ import (
 type remoteQueueDriver interface {
 	ID() string
 	Open(context.Context) error
-	Close()
+	Close(context.Context) error
 
 	// Get finds a job by job ID. For retryable jobs, this returns the latest
 	// job attempt.

--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -50,7 +50,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 
 	if opts.PruneFrequency > 0 && opts.TTL > 0 {
 		go func() {
-			defer recovery.LogStackTraceAndContinue("panic in remote queue group ticker")
+			defer recovery.LogStackTraceAndContinue("remote queue group background prune")
 			ticker := time.NewTicker(opts.PruneFrequency)
 			defer ticker.Stop()
 			for {
@@ -58,7 +58,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					grip.Error(message.WrapError(g.Prune(ctx), "problem pruning remote queue group database"))
+					grip.Error(message.WrapError(g.Prune(ctx), "pruning remote queue group database"))
 				}
 			}
 		}()
@@ -66,7 +66,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 
 	if opts.BackgroundCreateFrequency > 0 {
 		go func() {
-			defer recovery.LogStackTraceAndContinue("panic in remote queue group ticker")
+			defer recovery.LogStackTraceAndContinue("remote queue group background queue creation")
 			ticker := time.NewTicker(opts.BackgroundCreateFrequency)
 			defer ticker.Stop()
 			for {
@@ -74,7 +74,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					grip.Error(message.WrapError(g.startQueues(ctx), "problem starting external queues"))
+					grip.Error(message.WrapError(g.startQueues(ctx), "starting external queues"))
 				}
 			}
 		}()
@@ -87,6 +87,11 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 	return g, nil
 }
 
+// getQueues return all queues that are active. A queue is active if it is
+// either incomplete (still has pending or in progress jobs), or if it recently
+// completed a job within the TTL. Inactive queues (i.e. queues that are both
+// complete and have not recently completed a job within the TTL) are not
+// returned.
 func (g *remoteMongoQueueGroupSingle) getQueues(ctx context.Context) ([]string, error) {
 	cursor, err := g.client.Database(g.dbOpts.DB).Collection(addGroupSuffix(g.opts.Prefix)).Aggregate(ctx,
 		[]bson.M{
@@ -143,6 +148,8 @@ func (g *remoteMongoQueueGroupSingle) startQueues(ctx context.Context) error {
 	}
 
 	catcher := grip.NewBasicCatcher()
+	// Refresh the TTLs on all the queues that were recently accessed or still
+	// have.
 	for _, id := range queues {
 		_, err := g.Get(ctx, id)
 		catcher.Add(err)
@@ -167,13 +174,24 @@ func (g *remoteMongoQueueGroupSingle) Get(ctx context.Context, id string) (amboy
 		return q, nil
 	}
 
-	driver, err := openNewMongoGroupDriver(ctx, g.opts.Prefix, g.dbOpts, id, g.client)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem opening driver for queue")
+	var driver remoteQueueDriver
+	if g.client != nil {
+		driver, err = openNewMongoGroupDriver(ctx, g.opts.Prefix, g.dbOpts, id, g.client)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating and opening group driver")
+		}
+	} else {
+		driver, err = newMongoGroupDriver(g.opts.Prefix, g.dbOpts, id)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating group driver")
+		}
+		if err := driver.Open(ctx); err != nil {
+			return nil, errors.Wrap(err, "opening group driver")
+		}
 	}
 
 	if err = queue.SetDriver(driver); err != nil {
-		return nil, errors.Wrap(err, "problem setting driver")
+		return nil, errors.Wrap(err, "setting driver")
 	}
 
 	if err = g.cache.Set(id, queue, g.opts.TTL); err != nil {
@@ -183,11 +201,11 @@ func (g *remoteMongoQueueGroupSingle) Get(ctx context.Context, id string) (amboy
 			return q, nil
 		}
 
-		return nil, errors.Wrap(err, "problem caching queue")
+		return nil, errors.Wrap(err, "caching queue")
 	}
 
 	if err := queue.Start(ctx); err != nil {
-		return nil, errors.Wrap(err, "problem starting queue")
+		return nil, errors.Wrap(err, "starting queue")
 	}
 
 	return queue, nil

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -201,12 +201,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -240,12 +243,16 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
+
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addGroupSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addGroupSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -278,12 +285,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil
@@ -316,12 +326,15 @@ func MongoDBQueueTestCases(client *mongo.Client) []QueueTestCase {
 				}
 
 				closer := func(ctx context.Context) error {
+					catcher := grip.NewBasicCatcher()
 					d := rq.Driver()
 					if d != nil {
-						d.Close()
+						catcher.Add(d.Close(ctx))
 					}
 
-					return client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx)
+					catcher.Add(client.Database(opts.MDB.DB).Collection(addJobsSuffix(name)).Drop(ctx))
+
+					return catcher.Resolve()
 				}
 
 				return q, closer, nil

--- a/queue/remote.go
+++ b/queue/remote.go
@@ -47,10 +47,9 @@ func (opts *MongoDBQueueCreationOptions) Validate() error {
 }
 
 func (opts *MongoDBQueueCreationOptions) build(ctx context.Context) (amboy.RetryableQueue, error) {
-	var driver remoteQueueDriver
-	var err error
 
 	var q remoteQueue
+	var err error
 	qOpts := remoteOptions{
 		numWorkers: opts.Size,
 		retryable:  opts.Retryable,
@@ -65,6 +64,7 @@ func (opts *MongoDBQueueCreationOptions) build(ctx context.Context) (amboy.Retry
 		}
 	}
 
+	var driver remoteQueueDriver
 	if opts.Client == nil {
 		if opts.MDB.UseGroups {
 			driver, err = newMongoGroupDriver(opts.Name, opts.MDB, opts.MDB.GroupName)

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -487,7 +487,11 @@ func (q *remoteBase) Close(ctx context.Context) {
 		}))
 	}
 	if q.driver != nil {
-		q.driver.Close()
+		grip.Warning(message.WrapError(q.driver.Close(ctx), message.Fields{
+			"message":  "driver closed with errors",
+			"service":  "amboy.queue.mdb",
+			"queue_id": q.ID(),
+		}))
 	}
 	if r := q.Runner(); r != nil {
 		r.Close(ctx)

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -471,6 +471,9 @@ func (q *remoteBase) Start(ctx context.Context) error {
 }
 
 func (q *remoteBase) Close(ctx context.Context) {
+	// TODO (EVG-14617): close the queue dispatcher and the driver _before_
+	// closing the runners (makes it less likely to dispatch more jobs that will
+	// just get cancelled).
 	if r := q.Runner(); r != nil {
 		r.Close(ctx)
 	}

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -39,6 +39,7 @@ type remoteBase struct {
 	dispatched   map[string]struct{}
 	runner       amboy.Runner
 	retryHandler amboy.RetryHandler
+	cancel       context.CancelFunc
 	mutex        sync.RWMutex
 }
 
@@ -446,6 +447,8 @@ func (q *remoteBase) Start(ctx context.Context) error {
 		return errors.New("cannot start queue with an uninitialized runner")
 	}
 
+	ctx, q.cancel = context.WithCancel(ctx)
+
 	err := q.runner.Start(ctx)
 	if err != nil {
 		return errors.Wrap(err, "problem starting runner in remote queue")
@@ -470,10 +473,22 @@ func (q *remoteBase) Start(ctx context.Context) error {
 	return nil
 }
 
+// Close closes all resources owned by the queue and stops any further
+// processing of the queue's work.
 func (q *remoteBase) Close(ctx context.Context) {
-	// TODO (EVG-14617): close the queue dispatcher and the driver _before_
-	// closing the runners (makes it less likely to dispatch more jobs that will
-	// just get cancelled).
+	if q.cancel != nil {
+		q.cancel()
+	}
+	if q.dispatcher != nil {
+		grip.Warning(message.WrapError(q.dispatcher.Close(ctx), message.Fields{
+			"message":  "dispatcher closed with errors",
+			"service":  "amboy.queue.mdb",
+			"queue_id": q.ID(),
+		}))
+	}
+	if q.driver != nil {
+		q.driver.Close()
+	}
 	if r := q.Runner(); r != nil {
 		r.Close(ctx)
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14617

* Close the dispatcher when the queue closes. This avoids two potential issues where a job can be stuck in progress:
    1. The queue might close (when queue groups are pruned or the app restarts), causing all job running threads to finish their jobs and exit, but a job might still dispatch because the dispatcher is still running. This can leave a job stranded in progress because it's been dispatched but there's no job runner to handle it.
    2. The dispatcher might also leave a job stuck in progress forever (until the app restarts) after a runner has already started executing a job. When the queue context is cancelled (e.g. during app shutdown), `Complete` might return early, which prevents the dispatcher from releasing the job.
* Close the driver when the queue closes. Only close the MongoDB client connection if it's owned by the driver (i.e. the driver initialized it and it wasn't passed in with the constructor).
* Cancel all queue threads when the queue closes (e.g. the stale retrying job monitor, the job server thread that populates the next job to be picked up by a job runner).
* Add some more docs.
* Tweak some error and logging messages.