### PR TITLE
EVG-14561: log extended job error message when it completes

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -71,7 +71,7 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 	})
 
 	ti := j.TimeInfo()
-	r := message.Fields{
+	msg := message.Fields{
 		"job_id":        j.ID(),
 		"job_type":      j.Type().Name,
 		"duration_secs": ti.Duration().Seconds(),
@@ -82,15 +82,11 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 		"pool":          id,
 		"max_time_secs": ti.MaxTime.Seconds(),
 	}
-	err := j.Error()
-	if err != nil {
-		r["error"] = err.Error()
-	}
 
-	if err != nil {
-		grip.Error(r)
+	if err := j.Error(); err != nil {
+		grip.Error(message.WrapError(err, msg))
 	} else {
-		grip.Info(r)
+		grip.Info(msg)
 	}
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14561

Rather than log just the short error string when a job completes, log the extended error details, including the stack trace.