### PR TITLE
EVG-14644: add option to consider a sample of jobs in Next

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -53,7 +53,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/amboy
       binary: make
       args: ["${make_args}", "${target}"]
-      add_expansions_to_env: true
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
       env:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}

--- a/interface.go
+++ b/interface.go
@@ -137,14 +137,14 @@ type JobTimeInfo struct {
 	End     time.Time `bson:"end,omitempty" json:"end,omitempty" yaml:"end,omitempty"`
 	// WaitUntil defers execution of a job until a particular time has elapsed.
 	// Support for this feature in Queue implementations is optional.
-	WaitUntil time.Time `bson:"wait_until,omitempty" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
+	WaitUntil time.Time `bson:"wait_until" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
 	// DispatchBy is a deadline before which the job must run. Support for this
 	// feature in Queue implementations is optional. Queues that support this
 	// feature may remove the job if the deadline has passed.
-	DispatchBy time.Time `bson:"dispatch_by,omitempty" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
+	DispatchBy time.Time `bson:"dispatch_by" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
 	// MaxTime is the maximum time that the job is allowed to run. If the
 	// runtime exceeds this duration, the Queue should abort the job.
-	MaxTime time.Duration `bson:"max_time,omitempty" json:"max_time,omitempty" yaml:"max_time,omitempty"`
+	MaxTime time.Duration `bson:"max_time" json:"max_time,omitempty" yaml:"max_time,omitempty"`
 }
 
 // JobRetryInfo stores configuration and information for a job that can retry.

--- a/interface.go
+++ b/interface.go
@@ -137,14 +137,14 @@ type JobTimeInfo struct {
 	End     time.Time `bson:"end,omitempty" json:"end,omitempty" yaml:"end,omitempty"`
 	// WaitUntil defers execution of a job until a particular time has elapsed.
 	// Support for this feature in Queue implementations is optional.
-	WaitUntil time.Time `bson:"wait_until" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
+	WaitUntil time.Time `bson:"wait_until,omitempty" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
 	// DispatchBy is a deadline before which the job must run. Support for this
 	// feature in Queue implementations is optional. Queues that support this
 	// feature may remove the job if the deadline has passed.
-	DispatchBy time.Time `bson:"dispatch_by" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
+	DispatchBy time.Time `bson:"dispatch_by,omitempty" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
 	// MaxTime is the maximum time that the job is allowed to run. If the
 	// runtime exceeds this duration, the Queue should abort the job.
-	MaxTime time.Duration `bson:"max_time" json:"max_time,omitempty" yaml:"max_time,omitempty"`
+	MaxTime time.Duration `bson:"max_time,omitempty" json:"max_time,omitempty" yaml:"max_time,omitempty"`
 }
 
 // JobRetryInfo stores configuration and information for a job that can retry.

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -124,6 +124,7 @@ func (opts *MongoDBOptions) Validate() error {
 	catcher.NewWhen(opts.URI == "", "must specify connection URI")
 	catcher.NewWhen(opts.DB == "", "must specify database")
 	catcher.NewWhen(opts.SampleSize < 0, "sample rate cannot be negative")
+	catcher.NewWhen(opts.Priority && opts.SampleSize > 0, "cannot sample next jobs when ordering them by priority")
 	catcher.NewWhen(opts.LockTimeout < 0, "lock timeout cannot be negative")
 	if opts.LockTimeout == 0 {
 		opts.LockTimeout = amboy.LockTimeout

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -66,9 +66,9 @@ const (
 	retryableJobStaleRetrying retryableJobFilter = "stale-retrying"
 )
 
-// MongoDBOptions is a struct passed to the NewMongo constructor to
-// communicate mgoDriver specific settings about the driver's behavior
-// and operation.
+// MongoDBOptions is a struct passed to the MongoDB driver constructor to
+// communicate MongoDB-specific settings about the driver's behavior and
+// operation.
 type MongoDBOptions struct {
 	URI                      string
 	DB                       string
@@ -87,6 +87,11 @@ type MongoDBOptions struct {
 	TTL time.Duration
 	// LockTimeout overrides the default job lock timeout if set.
 	LockTimeout time.Duration
+	// SampleSize is the number of jobs that the driver will consider from the
+	// next available ones. If it samples from the available jobs, the order of
+	// next jobs are randomized. By default, the driver does not sample from the
+	// next available jobs. SampleSize cannot be used if Priority is true.
+	SampleSize int
 }
 
 // defaultMongoDBURI is the default URI to connect to a MongoDB instance.
@@ -108,6 +113,7 @@ func DefaultMongoDBOptions() MongoDBOptions {
 		WaitInterval:             time.Second,
 		Format:                   amboy.BSON,
 		LockTimeout:              amboy.LockTimeout,
+		SampleSize:               0,
 	}
 }
 
@@ -117,7 +123,8 @@ func (opts *MongoDBOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(opts.URI == "", "must specify connection URI")
 	catcher.NewWhen(opts.DB == "", "must specify database")
-	catcher.NewWhen(opts.LockTimeout < 0, "cannot have negative lock timeout")
+	catcher.NewWhen(opts.SampleSize < 0, "sample rate cannot be negative")
+	catcher.NewWhen(opts.LockTimeout < 0, "lock timeout cannot be negative")
 	if opts.LockTimeout == 0 {
 		opts.LockTimeout = amboy.LockTimeout
 	}

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1242,7 +1242,7 @@ func (d *mongoDriver) Next(ctx context.Context) amboy.Job {
 			iter, err := d.getNextCursor(ctx)
 			if err != nil {
 				grip.Warning(message.WrapError(err, message.Fields{
-					"message":       "problem finding next job",
+					"message":       "problem finding jobs ready to dispatch",
 					"driver_id":     d.instanceID,
 					"service":       "amboy.queue.mdb",
 					"operation":     "retrieving next job",

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -580,21 +580,6 @@ func (s *DriverSuite) TestStatsCountsAreAccurate() {
 	s.Equal(numEnqueued+numRunning+numCompleted+numRetrying, stats.Total)
 }
 
-func (s *DriverSuite) TestNextMethodReturnsPendingJob() {
-	ctx, cancel := context.WithTimeout(s.ctx, 100*time.Millisecond)
-	defer cancel()
-
-	j := job.NewShellJob("echo foo", "")
-
-	s.Require().NoError(s.driver.Put(ctx, j))
-	stats := s.driver.Stats(ctx)
-	s.Require().Equal(1, stats.Total)
-
-	nextJob := s.driver.Next(ctx)
-	s.Require().NotNil(nextJob)
-	s.Equal(nextJob.ID(), j.ID())
-}
-
 func (s *DriverSuite) TestNextMethodDoesNotReturnLastJob() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14644

Currently, `Next` returns an unsorted cursor, so implicitly, it's returning job documents by the order of the index keys. This can lead to contention for the head of the queue, which becomes more contentious the more hosts (i.e. app servers) there are trying to get the next job. I added an option for MongoDB-backed queues to limit the number of jobs considered in each find query, and randomly shuffle the order of the jobs. I'm hoping this will reduce the issue of jobs dispatching too slowly when there are many pending jobs, but I can't be totally certain of the performance impact of this change.