### PR TITLE
EVG-14643: update the error count when adding errors

### DIFF
--- a/job/base.go
+++ b/job/base.go
@@ -70,6 +70,7 @@ func (b *Base) AddError(err error) {
 		defer b.mutex.Unlock()
 
 		b.status.Errors = append(b.status.Errors, err.Error())
+		b.status.ErrorCount = len(b.status.Errors)
 	}
 }
 
@@ -84,6 +85,7 @@ func (b *Base) AddRetryableError(err error) {
 	defer b.mutex.Unlock()
 
 	b.status.Errors = append(b.status.Errors, err.Error())
+	b.status.ErrorCount = len(b.status.Errors)
 	b.retryInfo.NeedsRetry = true
 }
 

--- a/job/base_test.go
+++ b/job/base_test.go
@@ -41,6 +41,7 @@ func (s *BaseCheckSuite) TestAddErrorWithNilObjectDoesNotChangeErrorState() {
 		s.base.AddError(nil)
 		s.NoError(s.base.Error())
 		s.Len(s.base.status.Errors, 0)
+		s.Zero(s.base.status.ErrorCount)
 		s.False(s.base.HasErrors())
 	}
 }
@@ -60,6 +61,7 @@ func (s *BaseCheckSuite) TestAddErrorsPersistsErrorsInJob() {
 		s.base.AddError(errors.New("foo"))
 		s.Error(s.base.Error())
 		s.Len(s.base.status.Errors, i)
+		s.Equal(i, s.base.status.ErrorCount)
 		s.True(s.base.HasErrors())
 		s.Len(strings.Split(s.base.Error().Error(), "\n"), i)
 	}

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -831,7 +831,6 @@ func (d *mongoDriver) Complete(ctx context.Context, j amboy.Job) error {
 
 func (d *mongoDriver) prepareInterchange(j amboy.Job) (*registry.JobInterchange, error) {
 	stat := j.Status()
-	stat.ErrorCount = len(stat.Errors)
 	stat.ModificationTime = time.Now()
 	j.SetStatus(stat)
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14643

For whatever reason, the error count used to only be updated when it was going to be stored in the database, so if you just called `AddError`, it wouldn't change the in-memory error count. Now it does.