### PR TITLE
EVG-14689: omit optional time fields

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -137,14 +137,14 @@ type JobTimeInfo struct {
 	End     time.Time `bson:"end,omitempty" json:"end,omitempty" yaml:"end,omitempty"`
 	// WaitUntil defers execution of a job until a particular time has elapsed.
 	// Support for this feature in Queue implementations is optional.
-	WaitUntil time.Time `bson:"wait_until" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
+	WaitUntil time.Time `bson:"wait_until,omitempty" json:"wait_until,omitempty" yaml:"wait_until,omitempty"`
 	// DispatchBy is a deadline before which the job must run. Support for this
 	// feature in Queue implementations is optional. Queues that support this
 	// feature may remove the job if the deadline has passed.
-	DispatchBy time.Time `bson:"dispatch_by" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
+	DispatchBy time.Time `bson:"dispatch_by,omitempty" json:"dispatch_by,omitempty" yaml:"dispatch_by,omitempty"`
 	// MaxTime is the maximum time that the job is allowed to run. If the
 	// runtime exceeds this duration, the Queue should abort the job.
-	MaxTime time.Duration `bson:"max_time" json:"max_time,omitempty" yaml:"max_time,omitempty"`
+	MaxTime time.Duration `bson:"max_time,omitempty" json:"max_time,omitempty" yaml:"max_time,omitempty"`
 }
 
 // JobRetryInfo stores configuration and information for a job that can retry.

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1131,19 +1131,30 @@ func (d *mongoDriver) getNextQuery() bson.M {
 
 	d.modifyQueryForGroup(qd)
 
-	timeLimits := bson.M{}
+	var timeLimits []bson.M
 	if d.opts.CheckWaitUntil {
-		timeLimits["time_info.wait_until"] = bson.M{"$lte": now}
+		checkWaitUntil := bson.M{"$or": []bson.M{
+			{"time_info.wait_until": bson.M{"$lte": now}},
+			{"time_info.wait_until": bson.M{"$exists": false}},
+		}}
+		timeLimits = append(timeLimits, checkWaitUntil)
 	}
+
 	if d.opts.CheckDispatchBy {
-		timeLimits["$or"] = []bson.M{
+		checkDispatchBy := bson.M{"$or": []bson.M{
 			{"time_info.dispatch_by": bson.M{"$gt": now}},
+			{"time_info.dispatch_by": bson.M{"$exists": false}},
+			// TODO (EVG-XXX): remove zero value case after 90 day TTL
+			// (2022-01-01) since the field will be omitted.
 			{"time_info.dispatch_by": time.Time{}},
-		}
+		}}
+		timeLimits = append(timeLimits, checkDispatchBy)
 	}
+
 	if len(timeLimits) > 0 {
-		qd = bson.M{"$and": []bson.M{qd, timeLimits}}
+		qd = bson.M{"$and": append(timeLimits, qd)}
 	}
+
 	return qd
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14689

Exclude time restrictions (dispatch by, wait until, max time) from the job document if they're zero. The next job query is already indexed because there are indexes for the completed/in progress status; therefore, this change should not require any new indexes or anything and should be as performant as the old, non-omitted queries.