### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -53,7 +53,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/amboy
       binary: make
       args: ["${make_args}", "${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
       env:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
@@ -63,8 +63,8 @@ functions:
       type: setup
       params:
         command: make get-mongodb
+        include_expansions_in_env: ["MONGODB_URL"]
         env:
-          MONGODB_URL: ${mongodb_url}
           DECOMPRESS: ${decompress}
         working_dir: gopath/src/github.com/mongodb/amboy
     - command: subprocess.exec
@@ -169,11 +169,9 @@ buildvariants:
     display_name: Race Detector
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
-      test_timeout: 15m
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
     run_on:
       - archlinux-new-large
     tasks:
@@ -184,10 +182,8 @@ buildvariants:
     run_on:
       - archlinux-new-large
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
-      mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
-      test_timeout: 15m
+      MONGODB_URL: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
     tasks:
       - name: ".report"
         stepback: false
@@ -198,9 +194,8 @@ buildvariants:
       - ubuntu1804-large
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
     tasks:
       - build
       - ".test"
@@ -209,10 +204,8 @@ buildvariants:
     display_name: macOS 10.14
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
-      test_timeout: 15m
+      MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:
       - macos-1014
     tasks:
@@ -227,13 +220,9 @@ buildvariants:
       - windows-64-vs2017-large
       - windows-64-vs2017-small
     expansions:
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
       GOROOT: C:/golang/go1.16
       DISABLE_COVERAGE: true
-      test_timeout: 15m
-      mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
-      extension: ".exe"
-      archiveExt: ".zip"
+      MONGODB_URL: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
     tasks:
       - build
       - ".test"

--- a/makefile
+++ b/makefile
@@ -2,100 +2,82 @@
 name := amboy
 buildDir := build
 packages := $(name) dependency job registry pool queue rest logger management cli
+compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
 orgPath := github.com/mongodb
 projectPath := $(orgPath)/$(name)
 # end project configuration
 
-
- # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq (,$(gobin))
+# start environment setup
 gobin := go
+ifneq ($(GOROOT),)
+gobin := $(GOROOT)/bin/go
 endif
-gocache := $(abspath $(buildDir)/.cache)
-gopath := $(GOPATH)
-goroot := $(GOROOT)
+
 ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
-export GOCACHE := $(gocache)
-export GOPATH := $(gopath)
-export GOROOT := $(goroot)
+
 export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-
 .DEFAULT_GOAL := compile
-
 
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets
 
-
-# benchmark setup targets
-benchmarks:$(buildDir)/run-benchmarks .FORCE
+# start benchmark targets
+benchmarks: $(buildDir)/run-benchmarks .FORCE
 	./$(buildDir)/run-benchmarks $(run-benchmark)
-$(buildDir)/run-benchmarks:cmd/run-benchmarks/run-benchmarks.go
+$(buildDir)/run-benchmarks: cmd/run-benchmarks/run-benchmarks.go
 	$(gobin) build -o $@ $<
-# end benchmark setup targets
+# end benchmark targets
 
-
-_compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
-coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
+# start output files
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
 coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-# end dependency installation tools
+.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(coverageHtmlOutput)
+# end output files
 
-
-# userfacing targets for basic build and development operations
-lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-test:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
+# start basic development targets
+compile:
+	$(gobin) build $(compilePackages)
+test: $(foreach target,$(packages),$(buildDir)/output.$(target).test)
+lint: $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverage: $(coverageOutput)
 coverage-html: $(coverageHtmlOutput)
-compile $(buildDir):
-	$(gobin) build $(_compilePackages)
-phony += compile $(buildDir)
-# convenience targets for runing tests and coverage tasks on a
+phony := compile lint test coverage coverage-html
+
+# start convenience targets for running tests and coverage tasks on a
 # specific package.
-test-%:$(buildDir)/output.%.test
+test-%: $(buildDir)/output.%.test
 	
-coverage-%:$(buildDir)/output.%.coverage
+coverage-%: $(buildDir)/output.%.coverage
 	
-html-coverage-%:$(buildDir)/output.%.coverage.html
+html-coverage-%: $(buildDir)/output.%.coverage.html
 	
-lint-%:$(buildDir)/output.%.lint
+lint-%: $(buildDir)/output.%.lint
 	
-# end convienence targets
-phony := lint build test coverage coverage-html
-.PRECIOUS:$(testOutput) $(lintOutput) $(coverageOutput) $(coverageHtmlOutput)
-# end front-end
+# end convenience targets
+# end basic development targets
 
 # start test and coverage artifacts
-#    tests have compile and runtime deps. This varable has everything
-#    that the tests actually need to run. (The "build" target is
-#    intentional and makes these targets rerun as expected.)
 testArgs := -v -timeout=1h
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
-endif
-ifneq (,$(RUN_CASE))
-testArgs += -testify.m='$(RUN_CASE)'
 endif
 ifneq (,$(RUN_COUNT))
 testArgs += -count='$(RUN_COUNT)'
@@ -109,39 +91,42 @@ endif
 ifneq (,$(SKIP_LONG))
 testArgs += -short
 endif
-#    implementation for package coverage and test running,mongodb to produce
-#    and save test output.
-$(buildDir)/output.%.test:.FORCE
+$(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@!( grep -s -q "^FAIL" $@ && grep -s -q "^WARNING: DATA RACE" $@)
 	@(grep -s -q "^PASS" $@ || grep -s -q "no test files" $@)
-$(buildDir)/output.%.coverage:.FORCE
+$(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH),PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
-# mongodb utility targets
+# start mongodb targets
 mongodb/.get-mongodb:
 	rm -rf mongodb
 	mkdir -p mongodb
 	cd mongodb && curl "$(MONGODB_URL)" -o mongodb.tgz && $(DECOMPRESS) mongodb.tgz && chmod +x ./mongodb-*/bin/*
 	cd mongodb && mv ./mongodb-*/bin/* . && rm -rf db_files && rm -rf db_logs && mkdir -p db_files && mkdir -p db_logs
-get-mongodb:mongodb/.get-mongodb
+get-mongodb: mongodb/.get-mongodb
 	@touch $<
-start-mongod:mongodb/.get-mongodb
+start-mongod: mongodb/.get-mongodb
 	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet amboy
 	@echo "waiting for mongod to start up"
-check-mongod:mongodb/.get-mongodb
+check-mongod: mongodb/.get-mongodb
 	./mongodb/mongo --nodb --eval "assert.soon(function(x){try{var d = new Mongo(\"localhost:27017\"); return true}catch(e){return false}}, \"timed out connecting\")"
 	@echo "mongod is up"
-init-rs:mongodb/.get-mongodb
+init-rs: mongodb/.get-mongodb
 	./mongodb/mongo --eval 'rs.initiate()'
+phony += get-mongodb start-mongod check-mongod init-rs
 # end mongodb targets
 
 # start vendoring configuration
@@ -176,15 +161,17 @@ vendor-clean:
 	rm -rf vendor/go.mongodb.org/mongo-driver/vendor/github.com/kr/
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
 phony += vendor-clean
-# end vendoring tooling configuration
+# end vendoring configuration
 
 
-# clean and other utility targets
+# start cleanup targets
 clean:
 	rm -rf $(buildDir)
-phony += clean
-# end dependency targets
+clean-results:
+	rm -rf $(buildDir)/output.*
+phony += clean clean-results
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony)
+.PHONY: $(phony)


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.