### PR TITLE
EVG-15628: use relative path in evergreen.yaml

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -48,11 +48,11 @@ functions:
     - command: git.get_project
       type: system
       params:
-        directory: ${workdir}/amboy
+        directory: amboy
     - command: subprocess.exec
       type: setup
       params:
-        working_dir: ${workdir}/amboy
+        working_dir: amboy
         binary: make
         args: ["mod-tidy"]
         include_expansions_in_env: ["GOROOT"]
@@ -60,7 +60,7 @@ functions:
     command: subprocess.exec
     type: test
     params:
-      working_dir: ${workdir}/amboy
+      working_dir: amboy
       binary: make
       args: ["${make_args}", "${target}"]
       include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
@@ -75,23 +75,23 @@ functions:
         include_expansions_in_env: ["MONGODB_URL"]
         env:
           DECOMPRESS: ${decompress}
-        working_dir: ${workdir}/amboy
+        working_dir: amboy
     - command: subprocess.exec
       type: setup
       params:
         command: make start-mongod
-        working_dir: ${workdir}/amboy
+        working_dir: amboy
         background: true
     - command: subprocess.exec
       type: setup
       params:
         command: make check-mongod
-        working_dir: ${workdir}/amboy
+        working_dir: amboy
     - command: subprocess.exec
       type: setup
       params:
         command: make init-rs
-        working_dir: ${workdir}/amboy
+        working_dir: amboy
   parse-results:
     command: gotest.parse_files
     type: setup


### PR DESCRIPTION
`git.get_project` behaves incorrectly when using an absolute path in Windows (e.g. `${workdir}/amboy`) because it's not a native Windows absolute path (i.e. it doesn't look like `C:\data\mci\...` but is instead `/data/mci/...`). Although it would be preferable to have the CI system not behave inconsistently between Windows and non-Windows, it's easier to just change the invocations in the evergreen.yaml use to relative paths to avoid any Windows vs. Unix path issues.