### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,8 +176,8 @@ All project automation is managed by a makefile, with all output captured in the
    make lint                    # lints all packages
    make test-<package>          # runs the tests only for a specific packages
    make lint-<package>          # lints a specific package
-   make html-coverage-<package> # generates the coverage report for a specific package
-   make coverage-html           # generates the coverage report for all packages
+   make html-coverage-<package> # generates the HTML coverage report for a specific package
+   make html-coverage           # generates the HTML coverage report for all packages
 
 The buildsystem also has a number of flags, which may be useful for more
 iterative development workflows: ::

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -63,7 +63,7 @@ functions:
       working_dir: amboy
       binary: make
       args: ["${make_args}", "${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
       env:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
@@ -196,7 +196,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
@@ -221,7 +220,6 @@ buildvariants:
     run_on:
       - ubuntu1804-large
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
     tasks:
@@ -230,7 +228,6 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:
@@ -245,7 +242,6 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       GOROOT: C:/golang/go1.16
-      DISABLE_COVERAGE: true
       MONGODB_URL: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.3.zip
     tasks:
       - ".test"

--- a/makefile
+++ b/makefile
@@ -75,8 +75,8 @@ $(buildDir)/run-benchmarks: cmd/run-benchmarks/run-benchmarks.go
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(coverageHtmlOutput)
+htmlCoverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(htmlCoverageOutput)
 # end output files
 
 # start basic development targets
@@ -85,8 +85,8 @@ compile:
 test: $(foreach target,$(packages),$(buildDir)/output.$(target).test)
 lint: $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
-phony := compile lint test coverage coverage-html
+html-coverage: $(htmlCoverageOutput)
+phony := compile lint test coverage html-coverage
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.

--- a/makefile
+++ b/makefile
@@ -112,9 +112,6 @@ endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(SKIP_LONG))
 testArgs += -short
 endif
@@ -123,7 +120,7 @@ $(buildDir)/output.%.test: .FORCE
 	@grep -s -q "^PASS" $@
 $(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -coverprofile $@ | tee $(buildDir)/output.$*.test
-	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
+	-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 	@grep -s -q -e "^PASS" $(subst coverage,test,$@)
 $(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@

--- a/makefile
+++ b/makefile
@@ -120,7 +120,7 @@ $(buildDir)/output.%.test: .FORCE
 	@grep -s -q "^PASS" $@
 $(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -coverprofile $@ | tee $(buildDir)/output.$*.test
-	-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
+	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 	@grep -s -q -e "^PASS" $(subst coverage,test,$@)
 $(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.