### PR TITLE
EVG-15760: fix flaky adaptive order test

### DIFF
--- a/queue/adaptive_order_storage_test.go
+++ b/queue/adaptive_order_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -115,10 +116,13 @@ func (s *AdaptiveOrderItemsSuite) TestRefilterIgnoresWorkWithCanceledContext() {
 
 func (s *AdaptiveOrderItemsSuite) TestRefilterReordersItemsInSuite() {
 	ctx := context.Background()
-	originalOrder := []string{"foo", "bar", "buzz", "what", "foo"}
-	s.items.ready = []string{"foo", "bar", "buzz", "what", "foo"}
+	original := make([]string, 100)
+	for i := range original {
+		original[i] = utility.RandomString()
+	}
+	s.items.ready = original
 	s.items.refilter(ctx)
-	s.NotEqual(originalOrder, s.items.ready)
+	s.NotEqual(original, s.items.ready)
 }
 
 func (s *AdaptiveOrderItemsSuite) TestReadyTasksOnOtherQueuesMoved() {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15760

This fixes a test which was occasionally flaky because it had too few items, making it possible that it shuffles the items into the same order as the original. I increased the number of items in the slice to make it non-flaky.