### PR TITLE
EVG-15683: fix flaky queue group prune test

### DIFF
--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -347,8 +347,8 @@ func TestQueueGroup(t *testing.T) {
 					require.NoError(t, q2.Put(ctx, j2))
 					require.NoError(t, q2.Put(ctx, j3))
 
-					amboy.WaitInterval(ctx, q1, 100*time.Millisecond)
-					amboy.WaitInterval(ctx, q2, 100*time.Millisecond)
+					require.True(t, amboy.WaitInterval(ctx, q1, 100*time.Millisecond))
+					require.True(t, amboy.WaitInterval(ctx, q2, 100*time.Millisecond))
 
 					resultsQ1 := []amboy.Job{}
 					for result := range q1.Results(ctx) {

--- a/queue/group_test.go
+++ b/queue/group_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/grip"
@@ -473,7 +474,15 @@ func TestQueueGroup(t *testing.T) {
 					ctx, cancel := context.WithTimeout(bctx, 10*time.Second)
 					defer cancel()
 
-					g, closer, err := group.Constructor(ctx, time.Second)
+					ttl := time.Second
+					if group.Name == "Mongo" && utility.StringSliceContains([]string{"windows", "darwin"}, runtime.GOOS) {
+						// The tests are particularly slow on MacOS/Windows, so
+						// the queues need extra time to run all the jobs before
+						// being pruned.
+						ttl = 5 * time.Second
+					}
+
+					g, closer, err := group.Constructor(ctx, ttl)
 					defer func() { require.NoError(t, closer(ctx)) }()
 					require.NoError(t, err)
 					require.NotNil(t, g)
@@ -496,18 +505,18 @@ func TestQueueGroup(t *testing.T) {
 					require.NoError(t, q2.Put(ctx, j2))
 					require.NoError(t, q2.Put(ctx, j3))
 
-					amboy.WaitInterval(ctx, q2, 10*time.Millisecond)
-					amboy.WaitInterval(ctx, q1, 10*time.Millisecond)
+					require.True(t, amboy.WaitInterval(ctx, q2, 10*time.Millisecond))
+					require.True(t, amboy.WaitInterval(ctx, q1, 10*time.Millisecond))
 
 					// Queues should have completed work
-					assert.True(t, q1.Stats(ctx).IsComplete())
-					assert.True(t, q2.Stats(ctx).IsComplete())
+					require.True(t, q1.Stats(ctx).IsComplete())
+					require.True(t, q2.Stats(ctx).IsComplete())
 					assert.Equal(t, 1, q1.Stats(ctx).Completed)
 					assert.Equal(t, 2, q2.Stats(ctx).Completed)
 
 					require.Equal(t, 2, g.Len())
 
-					time.Sleep(2 * time.Second)
+					time.Sleep(ttl + time.Second)
 					require.NoError(t, g.Prune(ctx))
 
 					require.Equal(t, 0, g.Len())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15683

The queue group pruning test is flaky on slow machines (MacOS and Windows) because the queues in the queue group do not finish running all the jobs before they get TTL'd and deleted from the queue group. I bumped the TTL for the slow machines.