### PR TITLE
EVG-15952: use gofmt linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - gofmt
     - goimports
     - govet
     - ineffassign


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15952

`gofmt` is the standard style linter that comes packaged with go. I'm going to add `gofmt` to all repos once this is approved (you don't have to read the same PR 20+ times).