### PR TITLE
EVG-15956: clarify logged timing statistics when job completes

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -72,15 +72,15 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 
 	ti := j.TimeInfo()
 	msg := message.Fields{
-		"job_id":        j.ID(),
-		"job_type":      j.Type().Name,
-		"duration_secs": ti.Duration().Seconds(),
-		"dispatch_secs": ti.Start.Sub(ti.Created).Seconds(),
-		"pending_secs":  ti.End.Sub(ti.Created).Seconds(),
-		"queue_type":    fmt.Sprintf("%T", q),
-		"stat":          j.Status(),
-		"pool":          id,
-		"max_time_secs": ti.MaxTime.Seconds(),
+		"job_id":          j.ID(),
+		"job_type":        j.Type().Name,
+		"duration_secs":   ti.Duration().Seconds(),
+		"dispatch_secs":   ti.Start.Sub(ti.Created).Seconds(),
+		"turnaround_secs": ti.End.Sub(ti.Created).Seconds(),
+		"queue_type":      fmt.Sprintf("%T", q),
+		"stat":            j.Status(),
+		"pool":            id,
+		"max_time_secs":   ti.MaxTime.Seconds(),
 	}
 
 	if err := j.Error(); err != nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15956

Using the word "pending" in this case is deceptive because pending in an Amboy job refers to the state when the job is waiting in the queue to be dispatched to a worker. Here, it's being used to refer to the job's turnaround time (i.e. timespan between job submission and completion of its work). To keep the nomenclature consistent, I renamed the log field.

Once this is merged and Amboy is bumped in Evergreen/Cedar, I'll fix the Splunk Amboy dashboards that currently use "pending_secs" to populate the charts.