### PR TITLE
EVG-16648: remove duplicate key check TODO

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -799,9 +799,6 @@ func getMongoDupKeyErrors(err error) mongoDupKeyErrors {
 	return dupKeyErrs
 }
 
-// TODO: this logic is a copy-paste and could potentially be replaced by
-// upgrading the Go driver to a newer version:
-// (https://github.com/mongodb/mongo-go-driver/blob/213fb80b373f70dba4f9f516dc4c718abe41c76b/mongo/errors.go#L87-L96)
 func getMongoDupKeyWriteConcernError(err mongo.WriteException) *mongo.WriteConcernError {
 	wce := err.WriteConcernError
 	if wce == nil {

--- a/queue/remote_unordered_test.go
+++ b/queue/remote_unordered_test.go
@@ -52,9 +52,6 @@ func TestRemoteUnorderedMongoSuite(t *testing.T) {
 	suite.Run(t, tests)
 }
 
-// TODO run these same tests with different drivers by cloning the
-// above Test function and replacing the driverConstructor function.
-
 func (s *RemoteUnorderedSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	var err error


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16648

I removed the unfulfilled TODO and another outdated TODO. Unfortunately, we can't get rid of the hand-fashioned logic to find/parse the duplicate key errors from MongoDB because [the function referenced in the TODO](https://github.com/mongodb/mongo-go-driver/blob/213fb80b373f70dba4f9f516dc4c718abe41c76b/mongo/errors.go#L87-L96) only tells you if there is a duplicate key error, not which keys are duplicated. Therefore, we still have to parse the error message string to know which individual keys were duplicated.