### PR TITLE
EVG-15581: remove extra zero-value dispatch by check

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1222,9 +1222,6 @@ func (d *mongoDriver) getNextQuery() bson.M {
 		checkDispatchBy := bson.M{"$or": []bson.M{
 			{"time_info.dispatch_by": bson.M{"$gt": now}},
 			{"time_info.dispatch_by": bson.M{"$exists": false}},
-			// TODO (EVG-15581): remove zero value case after 90 day TTL
-			// (2022-02-01) since the field will be omitted.
-			{"time_info.dispatch_by": time.Time{}},
 		}}
 		timeLimits = append(timeLimits, checkDispatchBy)
 	}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -804,7 +804,7 @@ waitLoop:
 	stats := q.Stats(ctx)
 	require.Equal(t, numJobsToComplete+numJobsWaiting, stats.Total, "%+v", stats)
 	assert.Equal(t, numJobsToComplete, stats.Completed)
-	assert.Equal(t, numJobsWaiting, stats.Pending)
+	assert.Equal(t, numJobsWaiting, stats.Total-stats.Completed)
 
 	var numCompleted int
 	var numIncompleted int

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -741,7 +741,7 @@ func waitUntilTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 	} else if sz < 2 {
 		sz = 2
 	}
-	numJobs := sz * len(testNames)
+	numJobsToComplete := sz * len(testNames)
 	wg := &sync.WaitGroup{}
 
 	for i := 0; i < sz; i++ {
@@ -753,7 +753,7 @@ func waitUntilTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 				j := job.NewShellJob(cmd, "")
 				ti := j.TimeInfo()
 				require.Zero(t, ti.WaitUntil)
-				require.NoError(t, q.Put(ctx, j), fmt.Sprintf("(a) with %d workers", num))
+				require.NoError(t, q.Put(ctx, j))
 				_, ok := q.Get(ctx, j.ID())
 				require.True(t, ok)
 
@@ -764,14 +764,14 @@ func waitUntilTest(bctx context.Context, t *testing.T, test QueueTestCase, runne
 				})
 				ti2 := j2.TimeInfo()
 				require.NotZero(t, ti2.WaitUntil)
-				require.NoError(t, q.Put(ctx, j2), fmt.Sprintf("(b) with %d workers", num))
+				require.NoError(t, q.Put(ctx, j2))
 				_, ok = q.Get(ctx, j2.ID())
 				require.True(t, ok)
 			}
 		}(i)
 	}
 	wg.Wait()
-	// waitC for things to finish
+
 	const (
 		interval = 100 * time.Millisecond
 		maxTime  = 3 * time.Second
@@ -787,7 +787,7 @@ waitLoop:
 		case <-timer.C:
 			dur += interval
 			stat := q.Stats(ctx)
-			if stat.Completed >= numJobs {
+			if stat.Completed >= numJobsToComplete {
 				break waitLoop
 			}
 
@@ -800,23 +800,20 @@ waitLoop:
 	}
 
 	stats := q.Stats(ctx)
-	require.Equal(t, numJobs*2, stats.Total, "%+v", stats)
-	assert.Equal(t, numJobs, stats.Completed)
+	require.Equal(t, numJobsToComplete*2, stats.Total, "%+v", stats)
+	assert.Equal(t, numJobsToComplete, stats.Completed)
 
-	completed := 0
-	for result := range q.Results(ctx) {
-		status := result.Status()
-		ti := result.TimeInfo()
-
-		if status.Completed {
-			completed++
-			require.True(t, ti.WaitUntil.IsZero(), "val=%s id=%s", ti.WaitUntil, result.ID())
+	var numCompleted int
+	for info := range q.JobInfo(ctx) {
+		if info.Status.Completed {
+			numCompleted++
+			require.True(t, info.Time.WaitUntil.IsZero(), "val=%s id=%s", info.Time.WaitUntil, info.ID)
 		} else {
-			require.False(t, ti.WaitUntil.IsZero(), "val=%s id=%s", ti.WaitUntil, result.ID())
+			require.False(t, info.Time.WaitUntil.IsZero(), "val=%s id=%s", info.Time.WaitUntil, info.ID)
 		}
 	}
 
-	assert.Equal(t, numJobs, completed)
+	assert.Equal(t, numJobsToComplete, numCompleted)
 }
 
 func dispatchByTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {
@@ -830,7 +827,8 @@ func dispatchByTest(bctx context.Context, t *testing.T, test QueueTestCase, runn
 
 	require.NoError(t, q.Start(ctx))
 
-	for i := 0; i < 2*size.Size; i++ {
+	numJobsToComplete := size.Size
+	for i := 0; i < 2*numJobsToComplete; i++ {
 		j := job.NewShellJob("ls", "")
 		ti := j.TimeInfo()
 
@@ -852,15 +850,15 @@ waitLoop:
 			break waitLoop
 		case <-ticker.C:
 			stat := q.Stats(ctx)
-			if stat.Completed == size.Size {
+			if stat.Completed == numJobsToComplete {
 				break waitLoop
 			}
 		}
 	}
 
 	stats := q.Stats(ctx)
-	assert.Equal(t, 2*size.Size, stats.Total)
-	assert.Equal(t, size.Size, stats.Completed)
+	assert.Equal(t, 2*numJobsToComplete, stats.Total)
+	assert.Equal(t, numJobsToComplete, stats.Completed)
 }
 
 func maxTimeTest(bctx context.Context, t *testing.T, test QueueTestCase, runner PoolTestCase, size SizeTestCase) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-15581

Dispatch by was changed to an `omitempty` field sometime late in 2021. It should be fine to remove the zero time check since the 90 day job TTL has elapsed on all the app servers.

* Remove unnecessary zero time check for dispatch by.
* Small fix for a bug in the way the dispatch by/wait until tests are written.