### PR TITLE
EVG-15582: remove deprecated enqueue scopes field

### DIFF
--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -11,23 +11,19 @@ import (
 // instances. Interchange is also used internally as part of JobGroup
 // Job type.
 type JobInterchange struct {
-	Name          string              `bson:"_id" json:"name" yaml:"name"`
-	Type          string              `json:"type" bson:"type" yaml:"type"`
-	Group         string              `bson:"group,omitempty" json:"group,omitempty" yaml:"group,omitempty"`
-	Version       int                 `json:"version" bson:"version" yaml:"version"`
-	Priority      int                 `json:"priority" bson:"priority" yaml:"priority"`
-	Status        amboy.JobStatusInfo `bson:"status" json:"status" yaml:"status"`
-	Scopes        []string            `bson:"scopes,omitempty" json:"scopes,omitempty" yaml:"scopes,omitempty"`
-	EnqueueScopes []string            `bson:"enqueue_scopes,omitempty" json:"enqueue_scopes,omitempty" yaml:"enqueue_scopes,omitempty"`
-	// TODO (EVG-15582): remove this field after all jobs containing this field
-	// have hit their 90 day TTL (2022-02-01) since no jobs will be stored with
-	// this field anymore.
-	EnqueueAllScopesDeprecated bool                   `bson:"apply_scopes_on_enqueue,omitempty" json:"apply_scopes_on_enqueue,omitempty" yaml:"apply_scopes_on_enqueue,omitempty"`
-	EnqueueAllScopes           bool                   `bson:"enqueue_all_scopes,omitempty" json:"enqueue_all_scopes,omitempty" yaml:"enqueue_all_scopes,omitempty"`
-	RetryInfo                  amboy.JobRetryInfo     `bson:"retry_info" json:"retry_info,omitempty" yaml:"retry_info,omitempty"`
-	TimeInfo                   amboy.JobTimeInfo      `bson:"time_info" json:"time_info,omitempty" yaml:"time_info,omitempty"`
-	Job                        rawJob                 `json:"job" bson:"job" yaml:"job"`
-	Dependency                 *DependencyInterchange `json:"dependency,omitempty" bson:"dependency,omitempty" yaml:"dependency,omitempty"`
+	Name             string                 `bson:"_id" json:"name" yaml:"name"`
+	Type             string                 `json:"type" bson:"type" yaml:"type"`
+	Group            string                 `bson:"group,omitempty" json:"group,omitempty" yaml:"group,omitempty"`
+	Version          int                    `json:"version" bson:"version" yaml:"version"`
+	Priority         int                    `json:"priority" bson:"priority" yaml:"priority"`
+	Status           amboy.JobStatusInfo    `bson:"status" json:"status" yaml:"status"`
+	Scopes           []string               `bson:"scopes,omitempty" json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	EnqueueScopes    []string               `bson:"enqueue_scopes,omitempty" json:"enqueue_scopes,omitempty" yaml:"enqueue_scopes,omitempty"`
+	EnqueueAllScopes bool                   `bson:"enqueue_all_scopes,omitempty" json:"enqueue_all_scopes,omitempty" yaml:"enqueue_all_scopes,omitempty"`
+	RetryInfo        amboy.JobRetryInfo     `bson:"retry_info" json:"retry_info,omitempty" yaml:"retry_info,omitempty"`
+	TimeInfo         amboy.JobTimeInfo      `bson:"time_info" json:"time_info,omitempty" yaml:"time_info,omitempty"`
+	Job              rawJob                 `json:"job" bson:"job" yaml:"job"`
+	Dependency       *DependencyInterchange `json:"dependency,omitempty" bson:"dependency,omitempty" yaml:"dependency,omitempty"`
 }
 
 // MakeJobInterchange changes a Job interface into a JobInterchange
@@ -99,7 +95,7 @@ func (j *JobInterchange) Resolve(f amboy.Format) (amboy.Job, error) {
 	job.SetPriority(j.Priority)
 	job.SetStatus(j.Status)
 	job.SetEnqueueScopes(j.EnqueueScopes...)
-	job.SetEnqueueAllScopes(j.EnqueueAllScopes || j.EnqueueAllScopesDeprecated)
+	job.SetEnqueueAllScopes(j.EnqueueAllScopes)
 	job.UpdateTimeInfo(j.TimeInfo)
 	job.UpdateRetryInfo(j.RetryInfo.Options())
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15582

We can remove the deprecated enqueue scopes field. It's been replaced by two fields (`EnqueueScopes` and `EnqueueAllScopes`), and the 90 day TTL has elapsed, so no jobs have this deprecated field anymore.