### PR TITLE
EVG-16819: log queue ID when job finishes

### DIFF
--- a/pool/helpers.go
+++ b/pool/helpers.go
@@ -78,6 +78,7 @@ func executeJob(ctx context.Context, id string, j amboy.Job, q amboy.Queue) {
 		"dispatch_secs":   ti.Start.Sub(ti.Created).Seconds(),
 		"turnaround_secs": ti.End.Sub(ti.Created).Seconds(),
 		"queue_type":      fmt.Sprintf("%T", q),
+		"queue_id":        q.ID(),
 		"stat":            j.Status(),
 		"pool":            id,
 		"max_time_secs":   ti.MaxTime.Seconds(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16819

Include the queue ID when logging at the end of a job, which includes useful metadata such as the queue group name (if it's a queue group).