### PR TITLE
EVG-17370: support named queue settings matching a regexp

### DIFF
--- a/queue/group_remote_mongo.go
+++ b/queue/group_remote_mongo.go
@@ -41,7 +41,7 @@ type MongoDBQueueGroupOptions struct {
 	RegexpQueue []RegexpMongoDBQueueOptions
 
 	// PerQueue represent options for specific queues by ID. These take
-	// precedence over the DefaultQueue and PerQueueRegexp options.
+	// precedence over the DefaultQueue and RegexpQueue options.
 	PerQueue map[string]MongoDBQueueOptions
 
 	// PruneFrequency is how often inactive queues are checked to see if they


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17370

We already have options that can be applied to specific named queues in the queue group. This adds the ability to apply queue settings to named queues that match a regexp instead of an exact matching name.