### PR TITLE
EVG-17917: document backward compatibility warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,12 @@ API and Documentation
 See the `API documentation <https://godoc.org/github.com/mongodb/amboy>`
 for more information about amboy interfaces and internals.
 
+Notice for External Users
+-------------------------
+Amboy is being continuously developed for `Evergreen <https://github.com/evergreen-ci/evergreen>`. This is not a stable
+library and upgrades are at your own risk - it may be changed to add, remove, or modify functionality in a way that
+breaks backward compatibility.
+
 Development
 -----------
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17917

Some non-Evergreen developers have expressed interest in using Amboy. This is fine, but it's worth having a warning that it's not a stable library, so it has no promises of backward compatibility.