### PR TITLE
EVG-17256, EVG-17378: keep queues with retrying jobs active and improve retry handler logging

### DIFF
--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -96,11 +96,11 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 	return g, nil
 }
 
-// getQueues return all queues that are active. A queue is active if it is
-// either incomplete (still has pending or in progress jobs), or if it recently
-// completed a job within the TTL. Inactive queues (i.e. queues that are both
-// complete and have not recently completed a job within the TTL) are not
-// returned.
+// getQueues return all queues that are active. A queue is active if it still
+// has jobs to process (still has pending, in progress, or retrying jobs), or if
+// it recently completed a job within the TTL. Inactive queues (i.e. queues that
+// are have no jobs to process and have not recently completed a job within the
+// TTL) are not returned.
 func (g *remoteMongoQueueGroupSingle) getQueues(ctx context.Context) ([]string, error) {
 	cursor, err := g.opts.DefaultQueue.DB.Client.Database(g.opts.DefaultQueue.DB.DB).Collection(addGroupSuffix(g.opts.DefaultQueue.DB.Collection)).Aggregate(ctx,
 		[]bson.M{
@@ -113,6 +113,11 @@ func (g *remoteMongoQueueGroupSingle) getQueues(ctx context.Context) ([]string, 
 						{
 							"status.completed": true,
 							"status.mod_ts":    bson.M{"$gte": time.Now().Add(-g.opts.TTL)},
+						},
+						{
+							"status.completed":       true,
+							"retry_info.retryable":   true,
+							"retry_info.needs_retry": true,
 						},
 					},
 				},

--- a/queue/group_remote_mongo_single.go
+++ b/queue/group_remote_mongo_single.go
@@ -99,7 +99,7 @@ func NewMongoDBSingleQueueGroup(ctx context.Context, opts MongoDBQueueGroupOptio
 // getQueues return all queues that are active. A queue is active if it still
 // has jobs to process (still has pending, in progress, or retrying jobs), or if
 // it recently completed a job within the TTL. Inactive queues (i.e. queues that
-// are have no jobs to process and have not recently completed a job within the
+// have no jobs to process and have not recently completed a job within the
 // TTL) are not returned.
 func (g *remoteMongoQueueGroupSingle) getQueues(ctx context.Context) ([]string, error) {
 	cursor, err := g.opts.DefaultQueue.DB.Client.Database(g.opts.DefaultQueue.DB.DB).Collection(addGroupSuffix(g.opts.DefaultQueue.DB.Collection)).Aggregate(ctx,

--- a/queue/group_remote_mongo_test.go
+++ b/queue/group_remote_mongo_test.go
@@ -28,7 +28,7 @@ func TestMongoDBQueueGroup(t *testing.T) {
 		"Mongo": func(ctx context.Context, opts MongoDBQueueGroupOptions) (amboy.QueueGroup, error) {
 			return NewMongoDBQueueGroup(ctx, "prefix.", opts)
 		},
-		"MongoMerged": NewMongoDBSingleQueueGroup,
+		"MongoSingle": NewMongoDBSingleQueueGroup,
 	} {
 		t.Run(groupName, func(t *testing.T) {
 			t.Run("Get", func(t *testing.T) {


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-17256
https://jira.mongodb.org/browse/EVG-17378

* When a retryable MongoDB-backed queue still has jobs retrying, ensure that it is still considered active so that it doesn't get pruned from the queue group cache.
* Slightly improve the logging in the retry handler. As far as I can tell, the retry handler did the correct thing in EVG-17256, but it just wasn't clear from the logs.