### PR TITLE
EVG-18129: add option to explicitly specify next job hint

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -92,7 +92,7 @@ type MongoDBOptions struct {
 
 // PreferredIndexOptions provide options to explicitly set the index for use in
 // specific scenarios. If an index is not explicitly given, the index will be
-// picked auomatically.
+// picked automatically.
 type PreferredIndexOptions struct {
 	// NextJob determines the index pattern that will be used for requesting the
 	// next job in the queue.

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -1003,7 +1003,7 @@ func TestDriverNextJob(t *testing.T) {
 					}
 					for i := 0; i < queueSize; i++ {
 						next := driver.Next(ctx)
-						require.NotNil(t, next, "expected %d jobs in the queue waiting to run, but got %d", queueSize, i+1)
+						require.NotNil(t, next, "expected %d jobs in the queue waiting to run, but got %d", queueSize, i)
 						checkDispatched(t, next.Status())
 						if i < len(staleInProgJobs) {
 							seen, ok := staleInProgJobs[next.ID()]

--- a/queue/util.go
+++ b/queue/util.go
@@ -16,7 +16,12 @@ func randomString(x int) string {
 	return hex.EncodeToString(b)
 }
 
+// addJobsSuffix adds the expected collection suffix for the non-grouped queue
+// if it doesn't already have the suffix.
 func addJobsSuffix(s string) string {
+	if strings.HasSuffix(s, ".jobs") {
+		return s
+	}
 	return s + ".jobs"
 }
 
@@ -24,7 +29,12 @@ func trimJobsSuffix(s string) string {
 	return strings.TrimSuffix(s, ".jobs")
 }
 
+// addGroupSuffix adds the expected collection suffix for a queue group if it
+// doesn't already have the suffix.
 func addGroupSuffix(s string) string {
+	if strings.HasSuffix(s, ".group") {
+		return s
+	}
 	return s + ".group"
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18129

Make the index pattern hint for the next job query configurable by the user when setting up the MongoDB driver. We could use this in the future as well if we want to explicitly set indexes for other queries. By default, it doesn't hint any index for the query, so applications can pick their desired index according to their needs.