### PR TITLE
EVG-18128: check wait until in-memory

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -256,7 +256,7 @@ type JobRetryOptions struct {
 func (j JobTimeInfo) Duration() time.Duration { return j.End.Sub(j.Start) }
 
 // IsStale determines if the job is too old to be dispatched, and if
-// so, queues may remove or drop the job entirely.
+// so, queues may skip or dequeue the job.
 func (j JobTimeInfo) IsStale() bool {
 	if j.DispatchBy.IsZero() {
 		return false

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -59,7 +59,7 @@ func (d *dispatcherImpl) Dispatch(ctx context.Context, j amboy.Job) error {
 		return errors.New("cannot dispatch nil job")
 	}
 
-	if !isDispatchable(j.Status(), d.queue.Info().LockTimeout) {
+	if !isDispatchable(j.Status(), j.TimeInfo(), d.queue.Info().LockTimeout) {
 		return errors.New("cannot dispatch in progress or completed job")
 	}
 

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1449,7 +1449,7 @@ func (d *mongoDriver) tryDispatchJob(ctx context.Context, iter *mongo.Cursor, st
 		}
 
 		lockTimeout := d.LockTimeout()
-		dispatchable := isDispatchable(j.Status(), lockTimeout)
+		dispatchable := isDispatchable(j.Status(), j.TimeInfo(), lockTimeout)
 		if !dispatchable {
 			dispatchInfo.skips++
 			continue

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -945,11 +945,11 @@ func TestDriverNextJob(t *testing.T) {
 			mq := makeMockRemoteQueue(t, mdbOpts)
 
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, driver *mongoDriver){
-				"NextReturnsNoJobIfNoneExists": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"ReturnsNoJobIfNoneExists": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j := driver.Next(ctx)
 					assert.Nil(t, j)
 				},
-				"NextResolvesJobContentionAndDispatchesToSingleWorker": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"ResolvesJobContentionAndDispatchesToSingleWorker": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j := newMockJob()
 					j.SetID(utility.RandomString())
 					require.NoError(t, driver.Put(ctx, j))
@@ -994,7 +994,7 @@ func TestDriverNextJob(t *testing.T) {
 					}
 					assert.Equal(t, 1, numDispatches, "should have resolved the worker contention by dispatching the job to exactly one worker")
 				},
-				"NextDispatchesOnePendingJob": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"DispatchesOnePendingJob": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j := newMockJob()
 					j.SetID(utility.RandomString())
 					require.NoError(t, driver.Put(ctx, j))
@@ -1005,7 +1005,7 @@ func TestDriverNextJob(t *testing.T) {
 
 					checkDispatched(t, next.Status())
 				},
-				"NextIgnoresJobThatHasNotHitWaitUntilRequirementYet": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"IgnoresJobThatHasNotHitWaitUntilRequirementYet": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j := newMockJob()
 					j.SetID(utility.RandomString())
 					j.SetTimeInfo(amboy.JobTimeInfo{WaitUntil: time.Now().Add(time.Hour)})
@@ -1023,7 +1023,7 @@ func TestDriverNextJob(t *testing.T) {
 					require.NoError(t, err, "job that has not yet reached wait until requirement should remain enqueued")
 					assert.Equal(t, j.ID(), enqueuedJob.ID())
 				},
-				"NextIgnoresJobAndDequeuesJobThatHasExceededDispatchByRequirement": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"IgnoresJobAndDequeuesJobThatHasExceededDispatchByRequirement": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j := newMockJob()
 					j.SetID(utility.RandomString())
 					j.SetTimeInfo(amboy.JobTimeInfo{DispatchBy: time.Now().Add(-time.Hour)})
@@ -1045,7 +1045,7 @@ func TestDriverNextJob(t *testing.T) {
 					assert.True(t, amboy.IsJobNotFoundError(err), "job that exceeds dispatch by time should be dequeued")
 					assert.Zero(t, enqueuedJob)
 				},
-				"NextDispatchesEachPendingJob": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
+				"DispatchesEachPendingJob": func(ctx context.Context, t *testing.T, driver *mongoDriver) {
 					j0 := newMockJob()
 					j0.SetID(utility.RandomString())
 					j1 := newMockJob()

--- a/queue/driver_test.go
+++ b/queue/driver_test.go
@@ -935,6 +935,10 @@ func TestDriverNextJob(t *testing.T) {
 			mdbOpts.SampleSize = queueSize / 2
 			return mdbOpts
 		},
+		"UnsampledAndDoesNotQueryWaitUntil": func(t *testing.T, mdbOpts MongoDBOptions) MongoDBOptions {
+			mdbOpts.CheckWaitUntil = false
+			return mdbOpts
+		},
 		"Unsampled": func(t *testing.T, mdbOpts MongoDBOptions) MongoDBOptions { return mdbOpts },
 	} {
 		t.Run(queueType, func(t *testing.T) {

--- a/queue/remote_ordered.go
+++ b/queue/remote_ordered.go
@@ -114,7 +114,7 @@ func (q *remoteSimpleOrdered) Next(ctx context.Context) amboy.Job {
 					// this is just an optimization; if there's one dependency it's easy
 					// to move that job up in the queue by submitting it here.
 					dj, ok := q.Get(ctx, edges[0])
-					if ok && isDispatchable(dj.Status(), q.Info().LockTimeout) {
+					if ok && isDispatchable(dj.Status(), dj.TimeInfo(), q.Info().LockTimeout) {
 						// might need to make this non-blocking.
 						q.dispatcher.Release(ctx, job)
 						if q.dispatcher.Dispatch(ctx, dj) == nil {

--- a/queue/util.go
+++ b/queue/util.go
@@ -38,9 +38,15 @@ func addGroupSuffix(s string) string {
 	return s + ".group"
 }
 
-func isDispatchable(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
-	if isStaleJob(stat, lockTimeout) {
+func isDispatchable(stat amboy.JobStatusInfo, ti amboy.JobTimeInfo, lockTimeout time.Duration) bool {
+	if isStaleInProgressJob(stat, lockTimeout) {
 		return true
+	}
+	if ti.IsStale() {
+		return false
+	}
+	if !ti.IsDispatchable() {
+		return false
 	}
 	if stat.Completed {
 		return false
@@ -52,6 +58,6 @@ func isDispatchable(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
 	return true
 }
 
-func isStaleJob(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
+func isStaleInProgressJob(stat amboy.JobStatusInfo, lockTimeout time.Duration) bool {
 	return stat.InProgress && time.Since(stat.ModificationTime) > lockTimeout
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18128

`CheckWaitUntil` will omit jobs that haven't yet reached their `WaitUntil` requirement from the next job iterator results. However, if `CheckWaitUntil` is disabled, jobs that haven't hit their `WaitUntil` time will appear in the iterator results, so the queue should fall back to checking if `WaitUntil` is satisfied in-memory.