### PR TITLE
EVG-18304: allow the local limited size queue to accept jobs before processing starts

### DIFF
--- a/queue/limited_test.go
+++ b/queue/limited_test.go
@@ -45,7 +45,7 @@ func (s *limitedSizeQueueSuite) TestBufferForPendingWorkEqualToCapacityForResult
 
 	s.False(s.queue.Info().Started)
 	s.queue.Runner().Close(ctx)
-	s.Nil(s.queue.channel)
+	s.False(s.queue.Info().Started)
 	s.Error(s.queue.Put(ctx, job.NewShellJob("sleep 10", "")))
 
 	s.NoError(s.queue.Start(ctx))
@@ -73,16 +73,15 @@ func (s *limitedSizeQueueSuite) TestBufferForPendingWorkEqualToCapacityForResult
 
 func (s *limitedSizeQueueSuite) TestCallingStartMultipleTimesDoesNotImpactState() {
 	s.False(s.queue.Info().Started)
-	s.Nil(s.queue.channel)
 	ctx := context.Background()
 	s.NoError(s.queue.Start(ctx))
+	s.True(s.queue.Info().Started)
 
-	s.NotNil(s.queue.channel)
 	for i := 0; i < 100; i++ {
 		s.Error(s.queue.Start(ctx))
 	}
 
-	s.NotNil(s.queue.channel)
+	s.True(s.queue.Info().Started)
 }
 
 func (s *limitedSizeQueueSuite) TestCannotSetRunnerAfterQueueIsOpened() {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -499,7 +499,6 @@ func basicTest(bctx context.Context, t *testing.T, test QueueTestCase, runner Po
 
 	assert.Equal(t, numJobs, q.Stats(ctx).Total, fmt.Sprintf("with %d workers", size.Size))
 
-	grip.Infof("workers complete for %d worker smoke test", size.Size)
 	assert.Equal(t, numJobs, q.Stats(ctx).Completed, fmt.Sprintf("%+v", q.Stats(ctx)))
 	for result := range q.Results(ctx) {
 		assert.True(t, result.Status().Completed, fmt.Sprintf("with %d workers", size.Size))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18304

The local limited size queue will currently return an error if you try to enqueue jobs before the workers have started processing the queue. This isn't really necessary (and deviates from how all the other implementations behave), and it should be possible to pre-populate the queue before starting work on it, so I removed this limitation. This feature is useful for testing.