### PR TITLE
EVG-18240 break up Next query

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1308,8 +1308,7 @@ func (d *mongoDriver) getNextStaleInProgressQuery(now time.Time) bson.M {
 // getNextPendingQuery returns the query for the next available pending jobs.
 func (d *mongoDriver) getNextPendingQuery(now time.Time) bson.M {
 	qd := d.getPendingQuery(bson.M{})
-	d.modifyQueryForGroup(qd)
-	qd = d.modifyQueryForTimeLimits(qd, now)
+	d.modifyQueryForGroup(d.modifyQueryForTimeLimits(qd, now))
 
 	return qd
 }

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -83,10 +83,10 @@ type MongoDBOptions struct {
 	// lock ping, it will be considered stale and will be re-dispatched. If set,
 	// this overrides the default job lock timeout.
 	LockTimeout time.Duration
-	// SampleSize is the number of jobs that the driver will consider from the
-	// next available ones. If it samples from the available jobs, the order of
-	// next jobs are randomized. By default, the driver does not sample from the
-	// next available jobs. SampleSize cannot be used if Priority is true.
+	// SampleSize is the maximum number of jobs per set of jobs checked.
+	// If it samples from the available jobs, the order of next jobs are randomized.
+	// By default, the driver does not sample from the next available jobs.
+	// SampleSize cannot be used if Priority is true.
 	SampleSize int
 }
 

--- a/queue/driver_mongo_test.go
+++ b/queue/driver_mongo_test.go
@@ -48,6 +48,12 @@ func TestMongoDBOptions(t *testing.T) {
 			opts.SampleSize = -50
 			assert.Error(t, opts.Validate())
 		})
+		t.Run("FailsWithSampleSizeAndPriority", func(t *testing.T) {
+			opts := defaultMongoDBTestOptions()
+			opts.SampleSize = 100
+			opts.Priority = true
+			assert.Error(t, opts.Validate())
+		})
 		t.Run("FailsWithInvalidLockTimeout", func(t *testing.T) {
 			opts := defaultMongoDBTestOptions()
 			opts.LockTimeout = -time.Minute


### PR DESCRIPTION
[EVG-18240](https://jira.mongodb.org/browse/EVG-18240)

Break the query in two: the stale in-progress part first and, if anything's left of the sample size, the pending part.

It seemed the non-sample case could also be an aggregation so this combines them. It skips the check for exclusivity of sample size and priority since it's an invalid configuration anyways (did I get that right?).