### PR TITLE
EVG-20527 PutMany jobs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -60,9 +60,9 @@ func EnqueueUniqueJob(ctx context.Context, queue Queue, job Job) error {
 	return errors.WithStack(err)
 }
 
-// EnqueueUniqueJobs is a generic wrapper for adding jobs to queues (using the
-// PutMany() method), but that ignores duplicate job errors.
-func EnqueueUniqueJobs(ctx context.Context, queue Queue, jobs []Job) error {
+// EnqueueManyUniqueJobs is a generic wrapper for adding jobs to a queue (using the
+// PutMany() method) ignoring duplicate job errors.
+func EnqueueManyUniqueJobs(ctx context.Context, queue Queue, jobs []Job) error {
 	err := queue.PutMany(ctx, jobs)
 
 	if IsDuplicateJobError(err) {

--- a/errors.go
+++ b/errors.go
@@ -88,6 +88,10 @@ func (w WriteErrors) Error() string {
 	return catcher.String()
 }
 
+// Cause returns the primary cause of the WriteError. The primary cause is defined as follows:
+//   - If a non-duplicate-job error is encountered it is returned.
+//   - If every error is a duplicate job error and at least one of them is a duplicate scope error a duplicate scope error is returned.
+//   - If every error is a duplicate job error and none of them is a duplicate scope error a duplicate job error is returned.
 func (w WriteErrors) Cause() error {
 	if len(w.OtherErrors) > 0 {
 		return w

--- a/errors.go
+++ b/errors.go
@@ -73,12 +73,14 @@ func EnqueueManyUniqueJobs(ctx context.Context, queue Queue, jobs []Job) error {
 	return errors.WithStack(err)
 }
 
+// WriteErrors collates errors by error type.
 type WriteErrors struct {
 	DuplicateJobErrors   []error
 	DuplicateScopeErrors []error
 	OtherErrors          []error
 }
 
+// Error returns the string representation of the error.
 func (w WriteErrors) Error() string {
 	catcher := grip.NewBasicCatcher()
 	catcher.Extend(w.DuplicateScopeErrors)
@@ -109,7 +111,11 @@ func (w WriteErrors) Cause() error {
 }
 
 // CollateWriteErrors collates errors into a [WriteErrors].
-func CollateWriteErrors(errs []error) WriteErrors {
+func CollateWriteErrors(errs []error) *WriteErrors {
+	if len(errs) == 0 {
+		return nil
+	}
+
 	var writeErrs WriteErrors
 	for _, err := range errs {
 		if IsDuplicateJobScopeError(err) {
@@ -120,7 +126,7 @@ func CollateWriteErrors(errs []error) WriteErrors {
 			writeErrs.OtherErrors = append(writeErrs.OtherErrors, err)
 		}
 	}
-	return writeErrs
+	return &writeErrs
 }
 
 type duplJobError struct {

--- a/errors.go
+++ b/errors.go
@@ -60,6 +60,18 @@ func EnqueueUniqueJob(ctx context.Context, queue Queue, job Job) error {
 	return errors.WithStack(err)
 }
 
+// EnqueueUniqueJobs is a generic wrapper for adding jobs to queues (using the
+// PutMany() method), but that ignores duplicate job errors.
+func EnqueueUniqueJobs(ctx context.Context, queue Queue, jobs []Job) error {
+	err := queue.PutMany(ctx, jobs)
+
+	if IsDuplicateJobError(err) {
+		return nil
+	}
+
+	return errors.WithStack(err)
+}
+
 type duplJobError struct {
 	msg string
 }

--- a/errors.go
+++ b/errors.go
@@ -108,7 +108,7 @@ func (w *writeErrors) Cause() error {
 }
 
 // CollateWriteErrors collates errors into a [writeErrors].
-func CollateWriteErrors(errs []error) *writeErrors {
+func CollateWriteErrors(errs []error) error {
 	if len(errs) == 0 {
 		return nil
 	}

--- a/errors.go
+++ b/errors.go
@@ -108,7 +108,8 @@ func (w WriteErrors) Cause() error {
 	return duplicateError
 }
 
-func CollateWriteErrors(errs []error) error {
+// CollateWriteErrors collates errors into a [WriteErrors].
+func CollateWriteErrors(errs []error) WriteErrors {
 	var writeErrs WriteErrors
 	for _, err := range errs {
 		if IsDuplicateJobScopeError(err) {

--- a/errors.go
+++ b/errors.go
@@ -73,6 +73,7 @@ func EnqueueManyUniqueJobs(ctx context.Context, queue Queue, jobs []Job) error {
 	return errors.WithStack(err)
 }
 
+// writeErrors contains errors encountered while writing jobs to a queue.
 type writeErrors struct {
 	duplicateJobErrors   []error
 	duplicateScopeErrors []error

--- a/interface.go
+++ b/interface.go
@@ -315,6 +315,9 @@ type Queue interface {
 	// Put adds a job to the queue.
 	Put(context.Context, Job) error
 
+	// PutMany adds jobs to the queue.
+	PutMany(context.Context, []Job) error
+
 	// Get finds a Job by ID. The boolean return value indicates if the Job was
 	// found or not.
 	Get(context.Context, string) (Job, bool)

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
@@ -53,6 +54,14 @@ func (q *QueueTester) Put(ctx context.Context, j amboy.Job) error {
 		q.storage[j.ID()] = j
 		return nil
 	}
+}
+
+func (q *QueueTester) PutMany(ctx context.Context, jobs []amboy.Job) error {
+	catcher := grip.NewBasicCatcher()
+	for _, j := range jobs {
+		catcher.Add(q.Put(ctx, j))
+	}
+	return catcher.Resolve()
 }
 
 func (q *QueueTester) Save(ctx context.Context, j amboy.Job) error {

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -59,7 +59,7 @@ func (q *QueueTester) Put(ctx context.Context, j amboy.Job) error {
 func (q *QueueTester) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	catcher := grip.NewBasicCatcher()
 	for _, j := range jobs {
-		catcher.Add(q.Put(ctx, j))
+		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
 	return catcher.Resolve()
 }

--- a/pool/mock_queue_test.go
+++ b/pool/mock_queue_test.go
@@ -61,7 +61,7 @@ func (q *QueueTester) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	for _, j := range jobs {
 		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
-	return catcher.Resolve()
+	return amboy.CollateWriteErrors(catcher.Errors())
 }
 
 func (q *QueueTester) Save(ctx context.Context, j amboy.Job) error {

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -25,6 +25,8 @@ type remoteQueueDriver interface {
 	GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error)
 	// Put inserts a new job in the backing storage.
 	Put(context.Context, amboy.Job) error
+	// PutMany inserts new jobs in the backing storage.
+	PutMany(context.Context, []amboy.Job) error
 	// Save updates an existing job in the backing storage. Implementations may
 	// not allow calls to Save to run concurrently.
 	Save(context.Context, amboy.Job) error

--- a/queue/driver.go
+++ b/queue/driver.go
@@ -25,7 +25,8 @@ type remoteQueueDriver interface {
 	GetAllAttempts(ctx context.Context, id string) ([]amboy.Job, error)
 	// Put inserts a new job in the backing storage.
 	Put(context.Context, amboy.Job) error
-	// PutMany inserts new jobs in the backing storage.
+	// PutMany inserts new jobs in the backing storage. Each implementation can
+	// decide how to handle a mixture of errors.
 	PutMany(context.Context, []amboy.Job) error
 	// Save updates an existing job in the backing storage. Implementations may
 	// not allow calls to Save to run concurrently.

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -748,7 +748,7 @@ func (d *mongoDriver) getAtomicQuery(jobName string, stat amboy.JobStatusInfo) b
 
 func isMongoDupKey(err error) bool {
 	dupKeyErrs := getMongoDupKeyErrors(err)
-	return dupKeyErrs.writeConcernError != nil || len(dupKeyErrs.writeErrors) == dupKeyErrs.totalErrorCount || dupKeyErrs.commandError != nil
+	return dupKeyErrs.writeConcernError != nil || (len(dupKeyErrs.writeErrors) > 0 && len(dupKeyErrs.writeErrors) == dupKeyErrs.totalErrorCount) || dupKeyErrs.commandError != nil
 }
 
 func (d *mongoDriver) isMongoDupScope(err error) bool {

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -680,6 +680,12 @@ func (d *mongoDriver) Put(ctx context.Context, j amboy.Job) error {
 	return d.PutMany(ctx, []amboy.Job{j})
 }
 
+// PutMany enqueues multiple jobs on the queue.
+// Returns an error if any of the jobs cannot be inserted. If a non-duplicate-job error
+// is encountered it is returned. If every job is a duplicate job error then if any
+// of them is a duplicate scope error a duplicate scope error is returned.
+// If none of them is a duplicate scope error then a duplicate job error
+// is returned.
 func (d *mongoDriver) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	var jobInterchanges []any
 	for _, j := range jobs {

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -753,6 +753,7 @@ func (d *mongoDriver) getAtomicQuery(jobName string, stat amboy.JobStatusInfo) b
 	}
 }
 
+// toWriteError tries to convert the error to a WriteError if possible, but may simply return the error as-is if it's unable.
 func (d *mongoDriver) toWriteError(err error) error {
 	if we, ok := errors.Cause(err).(mongo.WriteException); ok {
 		var errs []error

--- a/queue/driver_mongo_test.go
+++ b/queue/driver_mongo_test.go
@@ -125,7 +125,6 @@ func TestPutMany(t *testing.T) {
 			for i := 0; i < 16000000; i++ {
 				sb.WriteString("a")
 			}
-			t.Log(len(sb.String()))
 			j0 := newMockJob()
 			j0.SetID(sb.String())
 			err = driver.PutMany(ctx, []amboy.Job{j0})

--- a/queue/driver_mongo_test.go
+++ b/queue/driver_mongo_test.go
@@ -93,7 +93,7 @@ func TestPutMany(t *testing.T) {
 	}()
 	opts.Client = client
 	defer func() {
-		client.Database(opts.DB).Drop(ctx)
+		assert.NoError(t, client.Database(opts.DB).Drop(ctx))
 	}()
 
 	driver, err := openNewMongoDriver(ctx, opts)
@@ -148,7 +148,7 @@ func TestPutMany(t *testing.T) {
 			assert.False(t, amboy.IsDuplicateJobError(err))
 		},
 		"DuplicateScopes": func(t *testing.T) {
-			client.Database(opts.DB).Collection(opts.Collection).Indexes().CreateOne(ctx, mongo.IndexModel{
+			_, err := client.Database(opts.DB).Collection(opts.Collection).Indexes().CreateOne(ctx, mongo.IndexModel{
 				Keys: bson.D{
 					bson.E{
 						Key:   "scopes",
@@ -157,6 +157,8 @@ func TestPutMany(t *testing.T) {
 				},
 				Options: options.Index().SetUnique(true).SetPartialFilterExpression(bson.M{"scopes": bson.M{"$exists": true}}),
 			})
+			require.NoError(t, err)
+
 			j0 := newMockJob()
 			j0.SetID("j0")
 			j0.SetScopes([]string{"scope"})
@@ -171,7 +173,7 @@ func TestPutMany(t *testing.T) {
 			assert.True(t, amboy.IsDuplicateJobScopeError(err))
 		},
 		"DuplicateAndDuplicateScopes": func(t *testing.T) {
-			client.Database(opts.DB).Collection(opts.Collection).Indexes().CreateOne(ctx, mongo.IndexModel{
+			_, err := client.Database(opts.DB).Collection(opts.Collection).Indexes().CreateOne(ctx, mongo.IndexModel{
 				Keys: bson.D{
 					bson.E{
 						Key:   "scopes",
@@ -180,6 +182,8 @@ func TestPutMany(t *testing.T) {
 				},
 				Options: options.Index().SetUnique(true).SetPartialFilterExpression(bson.M{"scopes": bson.M{"$exists": true}}),
 			})
+			require.NoError(t, err)
+
 			j0 := newMockJob()
 			j0.SetID("j0")
 			j0.SetScopes([]string{"scope"})
@@ -196,7 +200,7 @@ func TestPutMany(t *testing.T) {
 			assert.True(t, amboy.IsDuplicateJobScopeError(err))
 		},
 	} {
-		client.Database(opts.DB).Collection(opts.Collection).Drop(ctx)
+		require.NoError(t, client.Database(opts.DB).Collection(opts.Collection).Drop(ctx))
 		t.Run(testName, test)
 	}
 }

--- a/queue/limited.go
+++ b/queue/limited.go
@@ -122,7 +122,7 @@ func (q *limitedSizeLocal) PutMany(ctx context.Context, jobs []amboy.Job) error 
 	for _, j := range jobs {
 		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
-	return catcher.Resolve()
+	return amboy.CollateWriteErrors(catcher.Errors())
 }
 
 func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {

--- a/queue/limited.go
+++ b/queue/limited.go
@@ -120,7 +120,7 @@ func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
 func (q *limitedSizeLocal) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	catcher := grip.NewBasicCatcher()
 	for _, j := range jobs {
-		catcher.Add(q.Put(ctx, j))
+		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
 	return catcher.Resolve()
 }

--- a/queue/limited.go
+++ b/queue/limited.go
@@ -112,6 +112,19 @@ func (q *limitedSizeLocal) Put(ctx context.Context, j amboy.Job) error {
 	}
 }
 
+// PutMany adds jobs to the queue. It returns an error if the queue is not yet
+// opened or if any job of the same name already exists in the queue. If the queue is
+// at capacity, it will block until it can be added or the context is done;
+// waiting for these conditions can cause the other queue operations to also
+// block, so it is not recommended to pass a long-lived context to PutMany.
+func (q *limitedSizeLocal) PutMany(ctx context.Context, jobs []amboy.Job) error {
+	catcher := grip.NewBasicCatcher()
+	for _, j := range jobs {
+		catcher.Add(q.Put(ctx, j))
+	}
+	return catcher.Resolve()
+}
+
 func (q *limitedSizeLocal) Save(ctx context.Context, j amboy.Job) error {
 	if !q.Info().Started {
 		return errors.New("queue is not active")

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -153,7 +153,7 @@ func (q *limitedSizeSerializableLocal) Put(ctx context.Context, j amboy.Job) err
 func (q *limitedSizeSerializableLocal) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	catcher := grip.NewBasicCatcher()
 	for _, j := range jobs {
-		catcher.Add(q.Put(ctx, j))
+		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
 	return catcher.Resolve()
 }

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -155,7 +155,7 @@ func (q *limitedSizeSerializableLocal) PutMany(ctx context.Context, jobs []amboy
 	for _, j := range jobs {
 		catcher.Wrapf(q.Put(ctx, j), "putting job '%s'", j.ID())
 	}
-	return catcher.Resolve()
+	return amboy.CollateWriteErrors(catcher.Errors())
 }
 
 func (q *limitedSizeSerializableLocal) validateAndPreparePut(j amboy.Job) error {

--- a/queue/limited_serializable.go
+++ b/queue/limited_serializable.go
@@ -147,6 +147,17 @@ func (q *limitedSizeSerializableLocal) Put(ctx context.Context, j amboy.Job) err
 	return nil
 }
 
+// PutMany adds jobs to the queue, returning an error if the queue is not yet
+// opened or if the job already exists in the queue. If the queue is at
+// capacity, PutMany will fail.
+func (q *limitedSizeSerializableLocal) PutMany(ctx context.Context, jobs []amboy.Job) error {
+	catcher := grip.NewBasicCatcher()
+	for _, j := range jobs {
+		catcher.Add(q.Put(ctx, j))
+	}
+	return catcher.Resolve()
+}
+
 func (q *limitedSizeSerializableLocal) validateAndPreparePut(j amboy.Job) error {
 	j.UpdateTimeInfo(amboy.JobTimeInfo{
 		Created: time.Now(),

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -82,13 +82,24 @@ func (q *remoteBase) ID() string {
 // same job to a queue more than once, but this depends on the
 // implementation of the underlying driver.
 func (q *remoteBase) Put(ctx context.Context, j amboy.Job) error {
+	return q.PutMany(ctx, []amboy.Job{j})
+}
+
+// PutMany adds Jobs to the queue. It is generally an error to add the
+// same job to a queue more than once, but this depends on the
+// implementation of the underlying driver.
+func (q *remoteBase) PutMany(ctx context.Context, jobs []amboy.Job) error {
 	if q.driver == nil {
 		return errors.New("driver is not set")
 	}
-	if err := q.validateAndPreparePut(j); err != nil {
-		return err
+
+	for _, j := range jobs {
+		if err := q.validateAndPreparePut(j); err != nil {
+			return err
+		}
 	}
-	return q.driver.Put(ctx, j)
+
+	return q.driver.PutMany(ctx, jobs)
 }
 
 func (q *remoteBase) validateAndPreparePut(j amboy.Job) error {

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -269,7 +269,7 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) error {
 						"retry_count": count,
 						"message":     "after 10 retries, aborting marking job complete",
 					}))
-				} else if isMongoDupKey(err) || amboy.IsJobNotFoundError(err) {
+				} else if amboy.IsDuplicateJobError(err) || amboy.IsJobNotFoundError(err) {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"job_id":      id,
 						"driver_type": q.driverType,


### PR DESCRIPTION
[EVG-20527](https://jira.mongodb.org/browse/EVG-20527)

We observed that inserting many jobs (such as what the populators in evergreen do) takes a while because of all the round trips to the db. PutMany will allow adding many jobs to a queue at once.

It was difficult to decide what to return if there is a mixture of write errors, some duplicate key errors and some not. It seemed like the right thing to do (and the expedient thing for `EnqueueManyUniqueJobs`) was to only return a duplicate job error if the errors were _exclusively_ duplicate key errors. Reading [the driver code](https://github.com/mongodb/mongo-go-driver/blob/7355997933f8522a8a17379918b5cb91ff3674cc/mongo/collection.go#L321-L331) made me relatively confident that at least the driver assumes only one error is ever returned for each inserted document, so it seemed okay to assume duplicate insert will only return a duplicate key error and no others. Worst case we'll start noticing more non-duplicate job errors and we'll know this was a mistake.

I wondered if we wanted to replace the error code check with [the one from the driver](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#IsDuplicateKeyError), but left it for now. It wasn't clear to me why the error would be reported in any of the three ways. I asked in slack where the error would be expected, but no one responded 🤷 .