### PR TITLE
DEVPROD-69 skip insertion of an empty jobs slice

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -683,6 +683,10 @@ func (d *mongoDriver) Put(ctx context.Context, j amboy.Job) error {
 // PutMany enqueues multiple jobs on the queue.
 // Returns an [amboy.WriteError] if any of the jobs cannot be inserted.
 func (d *mongoDriver) PutMany(ctx context.Context, jobs []amboy.Job) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+
 	var jobInterchanges []any
 	for _, j := range jobs {
 		ji, err := registry.MakeJobInterchange(j, d.opts.Format)

--- a/queue/driver_mongo_test.go
+++ b/queue/driver_mongo_test.go
@@ -102,6 +102,14 @@ func TestPutMany(t *testing.T) {
 	}()
 
 	for testName, test := range map[string]func(*testing.T){
+		"NoJobs": func(t *testing.T) {
+			err = driver.PutMany(ctx, []amboy.Job{})
+			assert.NoError(t, err)
+		},
+		"NilJobs": func(t *testing.T) {
+			err = driver.PutMany(ctx, nil)
+			assert.NoError(t, err)
+		},
 		"DistinctJobs": func(t *testing.T) {
 			j0 := newMockJob()
 			j0.SetID("j0")


### PR DESCRIPTION
[DEVPROD-69](https://jira.mongodb.org/browse/DEVPROD-69)

If the job slice is empty or nil we should skip doing an insert because the driver returns an error for an empty insert. Not returning an error is consistent with the other remote drivers and queues.