### PR TITLE
DEVPROD-2303: use correct syntax for findng other jobs holding scopes

### DIFF
--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1489,7 +1489,7 @@ func (d *mongoDriver) isOtherJobHoldingScopes(ctx context.Context, j amboy.Job) 
 
 	query := bson.M{
 		"scopes": bson.M{"$in": j.Scopes()},
-		"$not":   d.getIDQuery(j.ID()),
+		"$nor":   d.getIDQuery(j.ID()),
 	}
 	d.modifyQueryForGroup(query)
 	num, err := d.getCollection().CountDocuments(ctx, query)

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -1489,7 +1489,7 @@ func (d *mongoDriver) isOtherJobHoldingScopes(ctx context.Context, j amboy.Job) 
 
 	query := bson.M{
 		"scopes": bson.M{"$in": j.Scopes()},
-		"$nor":   d.getIDQuery(j.ID()),
+		"$nor":   []bson.M{d.getIDQuery(j.ID())},
 	}
 	d.modifyQueryForGroup(query)
 	num, err := d.getCollection().CountDocuments(ctx, query)


### PR DESCRIPTION
Use the correct logical operator to negate the query. This query fix shouldn't change job dispatching, as this query is indexed and is only used to reduce the number of duplicate job errors due to racing to dispatch jobs that hold the same scopes.

Tested in a local DB to verify that `$nor` performs a logical NOT of the listed clause.