### PR TITLE
DEVPROD-7334: log ping interval

### DIFF
--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -240,6 +240,7 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 
+	pingStartedAt := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
@@ -263,6 +264,7 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 				"service":       "amboy.queue.dispatcher",
 				"ping_iter":     iters,
 				"ping_interval": pingInterval,
+				"ping_secs":     time.Since(pingStartedAt).Seconds(),
 				"lock_timeout":  q.Info().LockTimeout,
 				"stat":          j.Status(),
 			})

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -236,7 +236,8 @@ func (d *dispatcherImpl) waitForPing(ctx context.Context, info dispatcherInfo) e
 func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 	var iters int
 	lockTimeout := q.Info().LockTimeout
-	ticker := time.NewTicker(lockTimeout / 4)
+	pingInterval := lockTimeout / 4
+	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -257,11 +258,13 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 			}
 
 			grip.Debug(message.Fields{
-				"queue_id":  q.ID(),
-				"job_id":    j.ID(),
-				"service":   "amboy.queue.dispatcher",
-				"ping_iter": iters,
-				"stat":      j.Status(),
+				"queue_id":      q.ID(),
+				"job_id":        j.ID(),
+				"service":       "amboy.queue.dispatcher",
+				"ping_iter":     iters,
+				"ping_interval": pingInterval,
+				"lock_timeout":  q.Info().LockTimeout,
+				"stat":          j.Status(),
 			})
 
 			iters++


### PR DESCRIPTION
We currently log to Splunk based on how many job pings have occurred as a proxy for how long the job has run, but the ping interval can vary based on the configuration of the queue that the job is in. Add some extra logging for the ping duration and total time the ping has run, which can be used to determine how long the job has been running for.