### PR TITLE
DEVPROD-7468 don't recursively return a causer

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -90,7 +90,7 @@ func (w *writeErrors) Error() string {
 }
 
 // Cause returns the primary cause of the WriteError. The primary cause is defined as follows:
-//   - If a non-duplicate-job error is encountered it is returned.
+//   - If a non-duplicate-job error is encountered a plain error type is returned.
 //   - If every error is a duplicate job error and at least one of them is a duplicate scope error a duplicate scope error is returned.
 //   - If every error is a duplicate job error and none of them is a duplicate scope error a duplicate job error is returned.
 func (w *writeErrors) Cause() error {

--- a/errors.go
+++ b/errors.go
@@ -95,7 +95,12 @@ func (w *writeErrors) Error() string {
 //   - If every error is a duplicate job error and none of them is a duplicate scope error a duplicate job error is returned.
 func (w *writeErrors) Cause() error {
 	if len(w.otherErrors) > 0 {
-		return w
+		catcher := grip.NewBasicCatcher()
+		catcher.Extend(w.duplicateScopeErrors)
+		catcher.Extend(w.duplicateJobErrors)
+		catcher.Extend(w.otherErrors)
+
+		return catcher.Resolve()
 	}
 	if len(w.duplicateScopeErrors) > 0 {
 		return MakeDuplicateJobScopeError(w)


### PR DESCRIPTION
[DEVPROD-7468](https://jira.mongodb.org/browse/DEVPROD-7468)

If the a db write returns errors that aren't duplicate job/scope errors [this call to Cause](https://github.com/mongodb/amboy/blob/4bafe808c506bf69edb54aeddbfa65bb37062fb0/errors.go#L167) gets into an infinite recursion because the returned error implements `Cause`...

Return [a vanilla error](https://github.com/mongodb/grip/blob/584e10f183651989291528fc432824587903b6fd/errors_multi.go#L246) instead.
