### PR TITLE
DEVPROD-7311: add method to check for last job attempt

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -77,6 +77,8 @@ type Job interface {
 	// Error returns an error object if the job encountered an
 	// error. Typically if the job has not run, this is nil.
 	Error() error
+	// IsLastAttempt returns whether or not the job is on its final attempt. if
+	// true, the job will not retry.
 	IsLastAttempt() bool
 
 	// Lock and Unlock are responsible for handling the locking

--- a/interface.go
+++ b/interface.go
@@ -77,6 +77,7 @@ type Job interface {
 	// Error returns an error object if the job encountered an
 	// error. Typically if the job has not run, this is nil.
 	Error() error
+	IsLastAttempt() bool
 
 	// Lock and Unlock are responsible for handling the locking
 	// behavor for the job. Lock is responsible for setting the

--- a/job/base.go
+++ b/job/base.go
@@ -102,6 +102,25 @@ func (b *Base) HasErrors() bool {
 	return len(b.status.Errors) > 0
 }
 
+// IsLastAttempt determines if this is the final attempt of a retryable job. If
+// it's not retryable, this always return true.
+func (b *Base) IsLastAttempt() bool {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	if !b.retryInfo.Retryable {
+		return true
+	}
+	if b.retryInfo.Retryable && b.retryInfo.GetRemainingAttempts() == 0 {
+		return true
+	}
+	if !b.retryInfo.ShouldRetry() {
+		return true
+	}
+
+	return false
+}
+
 // SetID makes it possible to change the ID of an amboy.Job.
 func (b *Base) SetID(n string) {
 	b.mutex.Lock()

--- a/registry/mock_job_for_test.go
+++ b/registry/mock_job_for_test.go
@@ -118,6 +118,19 @@ func (j *JobTest) AddRetryableError(err error) {
 	j.Retry.NeedsRetry = true
 }
 
+func (j *JobTest) IsLastAttempt() bool {
+	if !j.Retry.Retryable {
+		return true
+	}
+	if j.Retry.Retryable && j.Retry.GetRemainingAttempts() == 0 {
+		return true
+	}
+	if !j.Retry.ShouldRetry() {
+		return true
+	}
+	return false
+}
+
 func (j *JobTest) Type() amboy.JobType {
 	return j.T
 }


### PR DESCRIPTION
[DEVPROD-7311](https://jira.mongodb.org/browse/DEVPROD-7311)

## Description
Add helper to check if the job is on its last attempt. This check is done quite a lot in Evergreen already, so I figured we might as well make a helper for it.

## Tests
Added unit tests.