### PR TITLE
DEVPROD-7058: truncate excessive errors when saving job

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -138,7 +138,9 @@ type JobStatusInfo struct {
 	ModificationTime  time.Time `bson:"mod_ts" json:"mod_time" yaml:"mod_time"`
 	ModificationCount int       `bson:"mod_count" json:"mod_count" yaml:"mod_count"`
 	ErrorCount        int       `bson:"err_count" json:"err_count" yaml:"err_count"`
-	Errors            []string  `bson:"errors,omitempty" json:"errors,omitempty" yaml:"errors,omitempty"`
+	// kim: NOTE: could be that there were a ton of errors and those errors were
+	// too long, which would require truncating/reducing errors.
+	Errors []string `bson:"errors,omitempty" json:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 // JobTimeInfo stores timing information for a job and is used by both the

--- a/interface.go
+++ b/interface.go
@@ -138,9 +138,7 @@ type JobStatusInfo struct {
 	ModificationTime  time.Time `bson:"mod_ts" json:"mod_time" yaml:"mod_time"`
 	ModificationCount int       `bson:"mod_count" json:"mod_count" yaml:"mod_count"`
 	ErrorCount        int       `bson:"err_count" json:"err_count" yaml:"err_count"`
-	// kim: NOTE: could be that there were a ton of errors and those errors were
-	// too long, which would require truncating/reducing errors.
-	Errors []string `bson:"errors,omitempty" json:"errors,omitempty" yaml:"errors,omitempty"`
+	Errors            []string  `bson:"errors,omitempty" json:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 // JobTimeInfo stores timing information for a job and is used by both the

--- a/queue/dispatcher.go
+++ b/queue/dispatcher.go
@@ -259,14 +259,14 @@ func pingJobLock(ctx context.Context, q amboy.Queue, j amboy.Job) error {
 			}
 
 			grip.Debug(message.Fields{
-				"queue_id":      q.ID(),
-				"job_id":        j.ID(),
-				"service":       "amboy.queue.dispatcher",
-				"ping_iter":     iters,
-				"ping_interval": pingInterval,
-				"ping_secs":     time.Since(pingStartedAt).Seconds(),
-				"lock_timeout":  q.Info().LockTimeout,
-				"stat":          j.Status(),
+				"queue_id":           q.ID(),
+				"job_id":             j.ID(),
+				"service":            "amboy.queue.dispatcher",
+				"ping_iter":          iters,
+				"ping_interval_secs": pingInterval.Seconds(),
+				"ping_secs":          time.Since(pingStartedAt).Seconds(),
+				"lock_timeout":       q.Info().LockTimeout,
+				"stat":               j.Status(),
 			})
 
 			iters++

--- a/queue/driver_mongo.go
+++ b/queue/driver_mongo.go
@@ -924,7 +924,7 @@ func (d *mongoDriver) doUpdate(ctx context.Context, ji *registry.JobInterchange)
 
 	res, err := d.getCollection().ReplaceOne(ctx, query, ji)
 	if err != nil {
-		return errors.Wrapf(d.toWriteError(err), "saving job '%s': %+v", ji.Name, res)
+		return errors.Wrapf(d.toWriteError(err), "saving job '%s'", ji.Name)
 	}
 
 	if res.MatchedCount == 0 {

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -254,21 +254,23 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) error {
 			if err != nil {
 				if attempt >= maxAttempts {
 					grip.Warning(message.WrapError(err, message.Fields{
-						"job_id":       id,
-						"driver_type":  q.driverType,
-						"job_type":     j.Type().Name,
-						"driver_id":    q.driver.ID(),
-						"num_attempts": attempt,
-						"message":      fmt.Sprintf("after %d attempts, aborting marking job complete", attempt),
+						"message":       fmt.Sprintf("after %d attempts, aborting marking job complete", attempt),
+						"job_id":        id,
+						"driver_type":   q.driverType,
+						"job_type":      j.Type().Name,
+						"driver_id":     q.driver.ID(),
+						"num_attempts":  attempt,
+						"duration_secs": time.Since(startAt).Seconds(),
 					}))
 				} else if amboy.IsDuplicateJobError(err) || amboy.IsJobNotFoundError(err) {
 					grip.Warning(message.WrapError(err, message.Fields{
-						"job_id":       id,
-						"driver_type":  q.driverType,
-						"job_type":     j.Type().Name,
-						"driver_id":    q.driver.ID(),
-						"num_attempts": attempt,
-						"message":      "attempting to complete job without lock",
+						"message":       "attempting to complete job without lock",
+						"job_id":        id,
+						"driver_type":   q.driverType,
+						"job_type":      j.Type().Name,
+						"driver_id":     q.driver.ID(),
+						"num_attempts":  attempt,
+						"duration_secs": time.Since(startAt).Seconds(),
 					}))
 				} else {
 					timer.Reset(retryInterval)

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -252,7 +252,7 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) error {
 
 			err = q.driver.Complete(ctx, j)
 			if err != nil {
-				if attempt > maxAttempts {
+				if attempt >= maxAttempts {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"job_id":       id,
 						"driver_type":  q.driverType,

--- a/queue/remote_base.go
+++ b/queue/remote_base.go
@@ -252,23 +252,14 @@ func (q *remoteBase) Complete(ctx context.Context, j amboy.Job) error {
 
 			err = q.driver.Complete(ctx, j)
 			if err != nil {
-				if time.Since(startAt) > time.Minute+q.Info().LockTimeout {
-					grip.Warning(message.WrapError(err, message.Fields{
-						"job_id":       id,
-						"job_type":     j.Type().Name,
-						"driver_type":  q.driverType,
-						"num_attempts": attempt,
-						"driver_id":    q.driver.ID(),
-						"message":      "job took too long to mark complete",
-					}))
-				} else if attempt > maxAttempts {
+				if attempt > maxAttempts {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"job_id":       id,
 						"driver_type":  q.driverType,
 						"job_type":     j.Type().Name,
 						"driver_id":    q.driver.ID(),
 						"num_attempts": attempt,
-						"message":      fmt.Sprintf("after %d retries, aborting marking job complete", attempt),
+						"message":      fmt.Sprintf("after %d attempts, aborting marking job complete", attempt),
 					}))
 				} else if amboy.IsDuplicateJobError(err) || amboy.IsJobNotFoundError(err) {
 					grip.Warning(message.WrapError(err, message.Fields{

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -46,10 +46,14 @@ func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 	}
 
 	output := &JobInterchange{
-		Name:             j.ID(),
-		Type:             typeInfo.Name,
-		Version:          typeInfo.Version,
-		Priority:         j.Priority(),
+		Name:     j.ID(),
+		Type:     typeInfo.Name,
+		Version:  typeInfo.Version,
+		Priority: j.Priority(),
+		// kim: TODO: truncate errors in the status here (by checking total
+		// length). If we can't save the document, we should log some kind of
+		// warning that the job's errors had to be truncated due to excessive
+		// length and otherwise call it quits.
 		Status:           j.Status(),
 		TimeInfo:         j.TimeInfo(),
 		EnqueueScopes:    j.EnqueueScopes(),

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -27,7 +27,8 @@ type JobInterchange struct {
 }
 
 // MakeJobInterchange changes a Job interface into a JobInterchange
-// structure, for easier serialization.
+// structure, for easier serialization. This will truncate job errors if they
+// will take up an unreasonably large amount of space in its serialized form.
 func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 	typeInfo := j.Type()
 
@@ -46,9 +47,6 @@ func MakeJobInterchange(j amboy.Job, f amboy.Format) (*JobInterchange, error) {
 	}
 
 	status := j.Status()
-	// Since the job can accumulate an arbitrarly large number of errors and
-	// those errors can also be arbitrarily long, ensure that the errors are a
-	// reasonable length.
 	status.Errors = truncateJobErrors(status.Errors)
 
 	output := &JobInterchange{

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -80,7 +80,7 @@ func (s *JobInterchangeSuite) TestConversionToInterchangeMaintainsMetaDataFideli
 }
 
 func (s *JobInterchangeSuite) TestConversionToInterchangeTruncatesUnreasonablyLongErrorsInMetaData() {
-	const numErrs = 1000
+	const numErrs = 5000
 	allErrors := make([]string, 0, numErrs)
 	for i := 0; i < numErrs; i++ {
 		allErrors = append(allErrors, utility.MakeRandomString(10000))
@@ -92,9 +92,11 @@ func (s *JobInterchangeSuite) TestConversionToInterchangeTruncatesUnreasonablyLo
 	s.NoError(err)
 	s.Greater(len(allErrors), len(i.Status.Errors), "if jobs has too many errors, it should truncate some of them down to a reasonable amount")
 
-	statusWithAllErrs := i.Status
-	statusWithAllErrs.Errors = allErrors
-	s.Equal(s.job.Status(), statusWithAllErrs, "all other status fields except long errors should be maintained")
+	interchangeStatusWithoutErrs := i.Status
+	interchangeStatusWithoutErrs.Errors = nil
+	jobStatusWithoutErrs := s.job.Status()
+	jobStatusWithoutErrs.Errors = nil
+	s.Equal(jobStatusWithoutErrs, interchangeStatusWithoutErrs, "all other status fields except long errors should be maintained")
 }
 
 func (s *JobInterchangeSuite) TestConversionFromInterchangeMaintainsFidelity() {

--- a/registry/interchange_test.go
+++ b/registry/interchange_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -75,6 +77,24 @@ func (s *JobInterchangeSuite) TestConversionToInterchangeMaintainsMetaDataFideli
 		s.Equal(s.job.Type().Version, i.Version)
 		s.Equal(s.job.Status(), i.Status)
 	}
+}
+
+func (s *JobInterchangeSuite) TestConversionToInterchangeTruncatesUnreasonablyLongErrorsInMetaData() {
+	const numErrs = 1000
+	allErrors := make([]string, 0, numErrs)
+	for i := 0; i < numErrs; i++ {
+		allErrors = append(allErrors, utility.MakeRandomString(10000))
+	}
+	for _, err := range allErrors {
+		s.job.AddError(errors.New(err))
+	}
+	i, err := MakeJobInterchange(s.job, s.format)
+	s.NoError(err)
+	s.Greater(len(allErrors), len(i.Status.Errors), "if jobs has too many errors, it should truncate some of them down to a reasonable amount")
+
+	statusWithAllErrs := i.Status
+	statusWithAllErrs.Errors = allErrors
+	s.Equal(s.job.Status(), statusWithAllErrs, "all other status fields except long errors should be maintained")
 }
 
 func (s *JobInterchangeSuite) TestConversionFromInterchangeMaintainsFidelity() {


### PR DESCRIPTION
[DEVPROD-7058](https://jira.mongodb.org/browse/DEVPROD-7058)

The error from the generate.tasks job is that _the job itself_ was too large to save back to the DB when marking it complete, which prevented it from finishing. The only way I could practically see this happening is that the generate.tasks logic produced a huge number of errors that exceeded the MDB doc size limit. The Splunk logs hint that this may be the case, even though they don't directly say it (Splunk has the same issue - it's also unable to log events if the payload is too large).

I opted to truncate the errors when saving them back to the DB. Saving the entire error string back to the job isn't a requirement for Amboy to work correctly, and just knowing that there are errors and having a long snippet of the error is sufficient.

* Truncate errors when saving job back to the DB if the error is excessively long.
    * Warn when the errors are excessively long and need to be cut down.
* Improve logging a little bit when repeatedly trying to mark a job complete (and fix off by one errors in the retry loop).
* Drive-by fix an trivial issue where the job lock pinger logged duration in nanoseconds rather than seconds.