### PR TITLE
DEVPROD-8844: fix panic truncating errors

### DIFF
--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -98,7 +98,7 @@ func truncateJobErrors(errs []string) (truncated []string, isTruncated bool) {
 		truncatedErrs = errs[:maxNumErrors]
 	}
 	for i := range truncatedErrs {
-		if len(truncatedErrs[i]) >= maxLengthPerError {
+		if len(truncatedErrs[i]) > maxLengthPerError {
 			truncatedErrs[i] = truncatedErrs[i][:maxLengthPerError]
 		}
 	}

--- a/registry/interchange.go
+++ b/registry/interchange.go
@@ -93,9 +93,14 @@ func truncateJobErrors(errs []string) (truncated []string, isTruncated bool) {
 		return errs, false
 	}
 
-	truncatedErrs := errs[:maxNumErrors]
-	for i := range errs {
-		truncatedErrs[i] = truncatedErrs[i][:maxLengthPerError]
+	truncatedErrs := errs
+	if len(errs) > maxNumErrors {
+		truncatedErrs = errs[:maxNumErrors]
+	}
+	for i := range truncatedErrs {
+		if len(truncatedErrs[i]) >= maxLengthPerError {
+			truncatedErrs[i] = truncatedErrs[i][:maxLengthPerError]
+		}
 	}
 
 	return truncatedErrs, true


### PR DESCRIPTION
Fix panic truncating errors when there's fewer than `maxNumErrors` of them.