### PR TITLE
DEVPROD-8738: reduce log level for job running out of attempts

### DIFF
--- a/queue/retry.go
+++ b/queue/retry.go
@@ -246,7 +246,7 @@ func (rh *BasicRetryHandler) waitForJob(ctx context.Context) {
 
 			if err := rh.handleJob(ctx, j); err != nil && ctx.Err() == nil {
 				logLevel := level.Error
-				if strings.Contains(err.Error(), maxAttemptsError.Error()) {
+				if strings.Contains(err.Error(), errMaxAttempts.Error()) {
 					logLevel = level.Warning
 				}
 				grip.Log(logLevel, message.WrapError(err, message.Fields{
@@ -370,7 +370,7 @@ func (rh *BasicRetryHandler) handleJob(ctx context.Context, j amboy.Job) error {
 	return errors.Errorf("exhausted all %d attempts to enqueue retry job without success", rh.opts.MaxRetryAttempts)
 }
 
-var maxAttemptsError = errors.New("job has reached its maximum attempt limit")
+var errMaxAttempts = errors.New("job has reached its maximum attempt limit")
 
 func (rh *BasicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Job) (canRetryOnErr bool, err error) {
 	originalInfo := j.RetryInfo()
@@ -388,7 +388,7 @@ func (rh *BasicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Job) (ca
 			return false, errors.New("job in the queue indicates the job does not need to retry anymore")
 		}
 		if originalInfo.CurrentAttempt+1 >= newInfo.GetMaxAttempts() {
-			return false, maxAttemptsError
+			return false, errMaxAttempts
 		}
 
 		lockTimeout := rh.queue.Info().LockTimeout

--- a/queue/retry.go
+++ b/queue/retry.go
@@ -3,12 +3,14 @@ package queue
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
@@ -243,7 +245,11 @@ func (rh *BasicRetryHandler) waitForJob(ctx context.Context) {
 			}()
 
 			if err := rh.handleJob(ctx, j); err != nil && ctx.Err() == nil {
-				grip.Error(message.WrapError(err, message.Fields{
+				logLevel := level.Error
+				if strings.Contains(err.Error(), maxAttemptsError.Error()) {
+					logLevel = level.Warning
+				}
+				grip.Log(logLevel, message.WrapError(err, message.Fields{
 					"message":     "could not retry job",
 					"queue_id":    rh.queue.ID(),
 					"job_id":      j.ID(),
@@ -364,6 +370,8 @@ func (rh *BasicRetryHandler) handleJob(ctx context.Context, j amboy.Job) error {
 	return errors.Errorf("exhausted all %d attempts to enqueue retry job without success", rh.opts.MaxRetryAttempts)
 }
 
+var maxAttemptsError = errors.New("job has reached its maximum attempt limit")
+
 func (rh *BasicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Job) (canRetryOnErr bool, err error) {
 	originalInfo := j.RetryInfo()
 
@@ -380,7 +388,7 @@ func (rh *BasicRetryHandler) tryEnqueueJob(ctx context.Context, j amboy.Job) (ca
 			return false, errors.New("job in the queue indicates the job does not need to retry anymore")
 		}
 		if originalInfo.CurrentAttempt+1 >= newInfo.GetMaxAttempts() {
-			return false, errors.New("job has reached its maximum attempt limit")
+			return false, maxAttemptsError
 		}
 
 		lockTimeout := rh.queue.Info().LockTimeout

--- a/queue/retry_test.go
+++ b/queue/retry_test.go
@@ -276,6 +276,7 @@ func TestRetryHandlerImplementations(t *testing.T) {
 
 					j := newMockRetryableJob("id")
 					j.UpdateRetryInfo(amboy.JobRetryOptions{
+						NeedsRetry:     utility.TruePtr(),
 						CurrentAttempt: utility.ToIntPtr(9),
 						MaxAttempts:    utility.ToIntPtr(10),
 					})


### PR DESCRIPTION
[DEVPROD-8738](https://jira.mongodb.org/browse/DEVPROD-8738)

### Description
Reduce error to warning if job runs out of retries. Keeping this log but reducing the log level makes it so that we can still use it for investigation without triggering the error rate alert. This log is good for investigation purposes because we can't assume that every single job implementation will log something special when it runs out of attempts, and running out of retries could indicate that Evergreen is giving up on doing some work that it ought to do.

As for the question of whether this over-logs and is using up our Splunk log limits, during the insufficient capacity outage, this log only used about 0.05% of our Splunk log limit, so removing it wouldn't make a meaningful difference to our Splunk usage.

### Testing
I checked the logging in the existing unit test to verify that it logged a warning rather than error when the job runs out of attempts.